### PR TITLE
Refactor tool calls to avoid Dict[str|any] types and increase test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ logs/
 
 # Cursor
 .cursor/
+
+# Local files
+.local/

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -205,8 +205,8 @@ The `release.sh` script provides a streamlined process for releasing a new versi
 
 ## Dependencies
 
-* **Core:** `python-dotenv`, `pydantic`, `fastapi`, `uvicorn`, `chromadb`, `fastmcp`, `numpy`.
-* **Optional (`[full]`):** `onnxruntime`, `sentence-transformers`, `httpx`.
+* **Core:** `python-dotenv`, `pydantic`, `fastapi`, `uvicorn`, `chromadb`, `fastmcp`, `numpy`, `onnxruntime`.
+* **Optional (`[full]`):** `sentence-transformers`, `httpx`.
 * **Development (`dev`):** `pytest`, `pytest-asyncio`, `pytest-cov`, `pytest-mock`, `pytest-xdist`, `black`, `isort`, `mypy`, `pylint`, `types-PyYAML`.
 
 See `pyproject.toml` for specific version constraints.

--- a/docs/mcp_test_flow.md
+++ b/docs/mcp_test_flow.md
@@ -6,18 +6,21 @@ This document outlines a sequence of Model Context Protocol (MCP) tool calls to 
 
 - The `chroma-mcp-server` is running and accessible via the MCP client (e.g., through Cursor's `chroma_test` or `chroma` configuration).
 - We are using the `mcp_chroma_test_` prefix for the tools as exposed in this environment.
+- **Recent Refactoring:** Document `add`, `update`, and `delete` tools now operate on **single documents** to improve compatibility with certain clients/models. Query and Get operations still support multiple items/results.
 
 **Error Handling Note:**
 
 - All tool implementations now raise `mcp.shared.exceptions.McpError` on failure (e.g., validation errors, collection not found, ChromaDB errors). Expect error responses to be structured accordingly, rather than returning `isError=True`.
 
-**Client-Side Limitations Note (Important):**
+**Client-Side Limitations Note (Updated):**
 
-- Testing has revealed that some MCP clients (including the one used in Cursor/VS Code during recent tests) have **limitations in correctly serializing *optional* list parameters** (e.g., `ids`, `metadatas` in `add_documents`; `limit` in `peek_collection`; `ids`, `limit`, `offset`, `include` in `get_documents`; `documents`, `metadatas` in `update_documents`; `ids` in `delete_documents`).
-- Providing values for these optional lists through such clients may result in a **string representation** being sent to the server (e.g., `'["id1", "id2"]'`) instead of a proper JSON array, leading to server-side **Pydantic validation errors (`type=list_type, input_type=str`)**.
-- Required list parameters (like `query_texts` in `query_documents`) seem to be handled correctly by these clients.
-- **Workaround:** When using affected clients, **omit the optional list parameters** and rely on default behaviors (e.g., auto-generated IDs, default limits) or alternative filtering methods (like `where` clauses if applicable).
-- Steps in this flow that rely heavily on optional list parameters (Steps 8-12b) were likely **skipped** during recent testing due to these client limitations.
+- Testing has revealed that some MCP clients (including the one used in Cursor/VS Code during recent tests) may have **limitations in correctly serializing list parameters**, especially optional ones. This can also affect required list parameters used in **query and get** tool variants.
+- Providing values for these lists through such clients may result in a **string representation** being sent to the server (e.g., `'["id1", "id2"]'`) instead of a proper JSON array, leading to server-side **Pydantic validation errors (`type=list_type, input_type=str`)**.
+- **Workaround:** When using affected clients for **query/get** operations:
+  - For *optional* lists, omit them and rely on defaults or alternative methods.
+  - For *required* lists (e.g., `ids` in `get_documents_by_ids`), this workaround might not be possible, and these specific tool variants may be unusable with that client.
+- **Single-item operations** (add, update, delete) should not be affected by this list issue.
+- Steps in this flow relying on list parameters for *query/get* (Steps 7, 8, 10, 12, 12b) might fail or need skipping with affected clients.
 
 ## Test Sequence
 
@@ -33,7 +36,7 @@ print(default_api.mcp_chroma_test_chroma_get_server_version(random_string="check
 
 ### 2. Create a New Collection
 
-Let's create a collection to store test data.
+Let's create a collection to store test data using the basic tool.
 
 ```tool_code
 print(default_api.mcp_chroma_test_chroma_create_collection(collection_name="mcp_flow_test_coll"))
@@ -49,7 +52,7 @@ Verify the new collection appears in the list.
 print(default_api.mcp_chroma_test_chroma_list_collections())
 ```
 
-**Note for Cursor Testing:** Due to potential limitations in Cursor's MCP client handling of optional parameters for this tool, you might need to omit the `name_contains` parameter when running this step. The call should be `print(default_api.mcp_chroma_test_chroma_list_collections())`. You will need to manually verify the collection exists in the full list returned.
+**Note:** Due to potential client limitations with optional parameters, `name_contains` is omitted. Verify manually if needed.
 
 *Expected Outcome:* A list including `"mcp_flow_test_coll"`.
 
@@ -61,31 +64,51 @@ Retrieve information about the newly created collection.
 print(default_api.mcp_chroma_test_chroma_get_collection(collection_name="mcp_flow_test_coll"))
 ```
 
-*Expected Outcome:* Details including name, ID, metadata, count (should be 0 initially), and sample entries (should be empty initially). If the collection doesn't exist, an `McpError` will be raised.
+*Expected Outcome:* Details including name, ID, metadata, count (should be 0 initially), and sample entries (should be empty initially).
 
-### 5. Add Documents
+### 5. Add a Document (with Metadata as JSON String)
 
-Add some sample documents to the collection.
+Add a sample document using the single-item tool that expects metadata as a JSON string.
 
 ```tool_code
-print(default_api.mcp_chroma_test_chroma_add_documents(
+print(default_api.mcp_chroma_test_chroma_add_document_with_metadata(
     collection_name="mcp_flow_test_coll",
-    documents=[
-        "This is the first test document.",
-        "Here is another document for testing purposes.",
-        "The quick brown fox jumps over the lazy dog."
-    ],
-    metadatas=[ # Optional: Provide metadata
-        {"source": "test_flow", "topic": "general"},
-        {"source": "test_flow", "topic": "specific"},
-        {"source": "test_flow", "topic": "pangram"}
-    ]
+    document="This is the first test document.",
+    metadata='{"source": "test_flow", "topic": "general"}' # Single JSON string
+    # increment_index is optional, defaults to False for single items
 ))
 ```
 
-**Note on Optional Parameters:** Due to the client-side limitations mentioned above, it's recommended to **omit `ids` and `metadatas`** when using affected clients. ChromaDB will auto-generate IDs. Subsequent steps relying on specific IDs (`doc1`, `doc2`, `doc3`) will need adjustment or may be skipped.
+*Expected Outcome:* Confirmation that 1 document was added. The response might include the auto-generated ID if the tool implementation returns it (design choice). Let's assume we don't know the ID for now.
 
-*Expected Outcome:* Confirmation that documents were added. If `ids` were omitted, the response will include the auto-generated UUIDs.
+### 5b. Add Another Document (with ID)
+
+Add another document, this time specifying an ID.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_add_document_with_id(
+    collection_name="mcp_flow_test_coll",
+    document="Here is another document for testing purposes.",
+    id="test-doc-2" # Parameter remains singular 'id' as per schema
+))
+```
+
+*Expected Outcome:* Confirmation that 1 document was added with the specified ID.
+
+### 5c. Add Third Document (with ID and Metadata)
+
+Add a third document with both ID and metadata.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_add_document_with_id_and_metadata(
+    collection_name="mcp_flow_test_coll",
+    document="The quick brown fox jumps over the lazy dog.",
+    id="test-doc-pangram",
+    metadata='{"source": "test_flow", "topic": "pangram"}'
+))
+```
+
+*Expected Outcome:* Confirmation that 1 document was added with the specified ID and metadata.
 
 ### 6. Peek at Collection
 
@@ -95,126 +118,84 @@ Check the first few entries.
 print(default_api.mcp_chroma_test_chroma_peek_collection(collection_name="mcp_flow_test_coll"))
 ```
 
-**Note on Optional Parameters:** Due to client-side limitations, the `limit` parameter is omitted here to rely on the default. Previous issues involving NumPy array evaluation in the response processing for this tool have been resolved (as of v0.1.57+), requiring a server restart to load the fix if encountered.
+**Note:** `limit` is omitted due to potential client issues.
 
-*Expected Outcome:* A sample of documents (default limit) and their data. If the collection is empty or doesn't exist, the result might be empty or an `McpError` respectively.
+*Expected Outcome:* A sample of documents (default limit is 10) including the ones we added (e.g., ID "test-doc-2", "test-doc-pangram", and one auto-generated ID).
 
 ### 7. Query Documents
 
-Perform a semantic search.
+Perform a semantic search. We'll use the basic query tool.
 
 ```tool_code
 print(default_api.mcp_chroma_test_chroma_query_documents(
     collection_name="mcp_flow_test_coll",
-    query_texts=["Tell me about test documents"] # Required list, should work
+    query_texts=["Tell me about test documents"], # Required list, should work
+    # n_results is optional (defaults to 10), include is optional
 ))
 ```
 
-**Note on Optional Parameters:** Due to client-side limitations, optional parameters like `n_results`, `where`, `where_document`, `include` are omitted here.
+**Note:** Optional parameters omitted due to potential client issues. Use specific variants for filtering if needed and if the client supports them.
 
-*Expected Outcome:* A list of results (default number), likely including documents similar to the query text, with distances/similarities.
+*Expected Outcome (Client Limitation possible):* A list of results likely including relevant documents. May fail if client cannot handle `query_texts` list.
 
 ### 8. Get Specific Documents by ID
 
-Retrieve documents using their IDs.
+Retrieve documents using their known IDs. Use the specific `_by_ids` variant. **This step might fail with affected clients due to list handling.**
 
 ```tool_code
-# Adjust IDs if they were auto-generated in step 5
-print(default_api.mcp_chroma_test_chroma_get_documents(
-    collection_name="mcp_flow_test_coll"
-))
-```
-
-*Expected Outcome (if run without `ids` or filters):* An `McpError` due to missing required filter (`ids`, `where`, or `where_document`).
-*Expected Outcome (in affected clients):* This step is likely **skipped** as providing the optional `ids` list leads to validation errors.
-
-### 9. Update Documents
-
-Modify the content and metadata of an existing document.
-
-```tool_code
-# Adjust ID if it was auto-generated in step 5
-print(default_api.mcp_chroma_test_chroma_update_documents(
+# Use the IDs we specified earlier.
+print(default_api.mcp_chroma_test_chroma_get_documents_by_ids(
     collection_name="mcp_flow_test_coll",
-    ids=["some-auto-generated-id"] # Required list, but 'documents' and 'metadatas' are optional lists
+    ids=["test-doc-2", "test-doc-pangram"] # Required list
+    # include is optional
 ))
 ```
 
-*Expected Outcome (in affected clients):* This step is likely **skipped** or run without providing optional `documents`/`metadatas` due to client-side limitations with optional lists. If run only with `ids`, it might effectively do nothing if no other parameters are provided.
+*Expected Outcome (in affected clients):* Likely failure due to client list handling.
+*Expected Outcome (if successful):* JSON containing the requested documents "test-doc-2" and "test-doc-pangram".
+
+### 9. Update Document Content
+
+Modify a document's content using its ID. Use the single-item update tool.
+
+```tool_code
+# Use one of the known IDs.
+print(default_api.mcp_chroma_test_chroma_update_document_content(
+    collection_name="mcp_flow_test_coll",
+    id="test-doc-2", # Single ID
+    document="This document content has been updated." # Single document content
+))
+```
+
+**Note:** To update metadata, use `mcp_chroma_test_chroma_update_document_metadata` (takes single `id` and `metadata` dict/JSON string).
+
+*Expected Outcome:* Confirmation of update request for 1 document.
 
 ### 10. Verify Update with Get
 
-Retrieve the updated document to confirm changes.
+Retrieve the updated document using its ID. **This step might fail with affected clients due to list handling.**
 
 ```tool_code
-# Adjust ID if it was auto-generated in step 5
-print(default_api.mcp_chroma_test_chroma_get_documents(
-    collection_name="mcp_flow_test_coll"
+# Use the same ID used in Step 9.
+print(default_api.mcp_chroma_test_chroma_get_documents_by_ids(
+    collection_name="mcp_flow_test_coll",
+    ids=["test-doc-2"] # Required list
 ))
 ```
 
-*Expected Outcome (in affected clients):* This step is likely **skipped** due to the same reasons as Step 8.
+*Expected Outcome (in affected clients):* Likely failure due to client list handling.
+*Expected Outcome (if successful):* JSON containing the document with ID "test-doc-2" showing the updated content.
 
-### 11. Delete Documents by ID
+### 11. Delete Document by ID
 
-Remove specific documents.
+Remove a specific document using its ID. Use the single-item delete tool.
 
 ```tool_code
-# Adjust IDs if they were auto-generated in step 5
-print(default_api.mcp_chroma_test_chroma_delete_documents(
-    collection_name="mcp_flow_test_coll"
+# Use one of the known IDs.
+print(default_api.mcp_chroma_test_chroma_delete_document_by_id(
+    collection_name="mcp_flow_test_coll",
+    id="test-doc-2" # Single ID
 ))
 ```
 
-*Expected Outcome (in affected clients):* This step is likely **skipped** as providing the optional `ids` list leads to validation errors. Deletion might be tested using `where` or `where_document` filters instead, or by deleting the whole collection (Step 13).
-
-### 12. Verify Deletion with Get
-
-Attempt to retrieve deleted documents (should fail or return empty).
-
-```tool_code
-# Adjust IDs if they were auto-generated in step 5
-print(default_api.mcp_chroma_test_chroma_get_documents(
-    collection_name="mcp_flow_test_coll"
-))
-```
-
-*Expected Outcome (in affected clients):* This step is likely **skipped** due to the same reasons as Step 8.
-
-### 12b. Attempt Get on Non-Existent Document
-
-Attempt to retrieve a document ID that never existed.
-
-```tool_code
-print(default_api.mcp_chroma_test_chroma_get_documents(
-    collection_name="mcp_flow_test_coll"
-))
-```
-
-*Expected Outcome (in affected clients):* This step is likely **skipped** due to the same reasons as Step 8.
-
-### 13. Delete Collection
-
-Clean up by deleting the test collection.
-
-```tool_code
-print(default_api.mcp_chroma_test_chroma_delete_collection(collection_name="mcp_flow_test_coll"))
-```
-
-*Expected Outcome:* Confirmation that the collection was deleted. If it doesn't exist, an `McpError` will be raised.
-
-### 14. Verify Collection Deletion
-
-Attempt to list the collection (should not be found).
-
-```tool_code
-print(default_api.mcp_chroma_test_chroma_list_collections()) # Omit name_contains due to potential client issues
-```
-
-**Note on Optional Parameters:** See note in step 3 regarding potential need to omit `name_contains`. Verify manually that `mcp_flow_test_coll` is absent from the full list.
-
-*Expected Outcome:* A list of collection names that does not include `mcp_flow_test_coll`.
-
----
-
-This flow covers the primary CRUD (Create, Read, Update, Delete) operations for both collections and documents. However, due to observed client-side limitations with optional list parameters, exercising Update and Delete operations on specific document IDs may require workarounds or different client environments.
+**Note:** Use filter variants (`

--- a/docs/mcp_test_flow.md
+++ b/docs/mcp_test_flow.md
@@ -44,6 +44,32 @@ print(default_api.mcp_chroma_test_chroma_create_collection(collection_name="mcp_
 
 *Expected Outcome:* Confirmation of creation with collection name, ID, and default metadata/settings. If the collection already exists, an `McpError` indicating this will be raised.
 
+### 2b. Create Collection with Metadata
+
+Create a second collection, this time specifying metadata upfront.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_create_collection_with_metadata(
+    collection_name="mcp_flow_test_coll_meta",
+    metadata='{"description": "Collection for metadata tests", "topic": "testing"}'
+))
+```
+
+*Expected Outcome:* Confirmation of creation with the specified metadata.
+
+### 2c. Rename Collection
+
+Rename the second collection.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_rename_collection(
+    collection_name="mcp_flow_test_coll_meta",
+    new_name="mcp_flow_test_coll_renamed"
+))
+```
+
+*Expected Outcome:* Confirmation of rename.
+
 ### 3. List Collections
 
 Verify the new collection appears in the list.
@@ -54,7 +80,7 @@ print(default_api.mcp_chroma_test_chroma_list_collections())
 
 **Note:** Due to potential client limitations with optional parameters, `name_contains` is omitted. Verify manually if needed.
 
-*Expected Outcome:* A list including `"mcp_flow_test_coll"`.
+*Expected Outcome:* A list including `"mcp_flow_test_coll"` and `"mcp_flow_test_coll_renamed"`.
 
 ### 4. Get Collection Details
 
@@ -110,6 +136,19 @@ print(default_api.mcp_chroma_test_chroma_add_document_with_id_and_metadata(
 
 *Expected Outcome:* Confirmation that 1 document was added with the specified ID and metadata.
 
+### 5d. Add Document (Basic)
+
+Add a basic document without specifying ID or metadata to the first collection.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_add_document(
+    collection_name="mcp_flow_test_coll",
+    document="This is a basic document with no extra info."
+))
+```
+
+*Expected Outcome:* Confirmation that 1 document was added (response might include the generated ID).
+
 ### 6. Peek at Collection
 
 Check the first few entries.
@@ -121,6 +160,16 @@ print(default_api.mcp_chroma_test_chroma_peek_collection(collection_name="mcp_fl
 **Note:** `limit` is omitted due to potential client issues.
 
 *Expected Outcome:* A sample of documents (default limit is 10) including the ones we added (e.g., ID "test-doc-2", "test-doc-pangram", and one auto-generated ID).
+
+### 6b. Get All Documents
+
+Retrieve all documents from the first collection (respecting potential default limits).
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_get_all_documents(collection_name="mcp_flow_test_coll"))
+```
+
+*Expected Outcome:* A list containing all documents currently in `mcp_flow_test_coll`.
 
 ### 7. Query Documents
 
@@ -138,6 +187,34 @@ print(default_api.mcp_chroma_test_chroma_query_documents(
 
 *Expected Outcome (Client Limitation possible):* A list of results likely including relevant documents. May fail if client cannot handle `query_texts` list.
 
+### 7b. Query with Metadata Filter (`where`)
+
+Perform a query filtering by metadata.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_query_documents_with_where_filter(
+    collection_name="mcp_flow_test_coll",
+    query_texts=["Tell me about pangrams"],
+    where={'topic': 'pangram'} # Filter for topic
+))
+```
+
+*Expected Outcome:* Results containing the "pangram" document.
+
+### 7c. Query with Document Filter (`where_document`)
+
+Perform a query filtering by document content.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_query_documents_with_document_filter(
+    collection_name="mcp_flow_test_coll",
+    query_texts=["Tell me about general test documents"],
+    where_document={'$contains': 'first test'} # Filter for content
+))
+```
+
+*Expected Outcome:* Results containing the document with "first test" in its content.
+
 ### 8. Get Specific Documents by ID
 
 Retrieve documents using their known IDs. Use the specific `_by_ids` variant. **This step might fail with affected clients due to list handling.**
@@ -153,6 +230,32 @@ print(default_api.mcp_chroma_test_chroma_get_documents_by_ids(
 
 *Expected Outcome (in affected clients):* Likely failure due to client list handling.
 *Expected Outcome (if successful):* JSON containing the requested documents "test-doc-2" and "test-doc-pangram".
+
+### 8b. Get Documents with Metadata Filter (`where`)
+
+Retrieve documents filtering by metadata.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_get_documents_with_where_filter(
+    collection_name="mcp_flow_test_coll",
+    where={'source': 'test_flow'} # Filter for source
+))
+```
+
+*Expected Outcome:* Documents matching the `source` metadata.
+
+### 8c. Get Documents with Document Filter (`where_document`)
+
+Retrieve documents filtering by content.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_get_documents_with_document_filter(
+    collection_name="mcp_flow_test_coll",
+    where_document={'$contains': 'basic document'} # Filter for content
+))
+```
+
+*Expected Outcome:* Documents containing "basic document".
 
 ### 9. Update Document Content
 
@@ -170,6 +273,20 @@ print(default_api.mcp_chroma_test_chroma_update_document_content(
 **Note:** To update metadata, use `mcp_chroma_test_chroma_update_document_metadata` (takes single `id` and `metadata` dict/JSON string).
 
 *Expected Outcome:* Confirmation of update request for 1 document.
+
+### 9b. Update Document Metadata
+
+Update the metadata of a document.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_update_document_metadata(
+    collection_name="mcp_flow_test_coll",
+    id="test-doc-pangram",
+    metadata={"source": "test_flow_updated", "topic": "pangram", "status": "updated"} # New metadata dict
+))
+```
+
+*Expected Outcome:* Confirmation of metadata update request.
 
 ### 10. Verify Update with Get
 
@@ -198,4 +315,196 @@ print(default_api.mcp_chroma_test_chroma_delete_document_by_id(
 ))
 ```
 
-**Note:** Use filter variants (`
+**Note:** Use filter variants (`delete_documents_by_where_filter`, `delete_documents_by_document_filter`) for bulk deletion based on criteria.
+
+*Expected Outcome:* Confirmation of delete request for 1 document.
+
+### 12. Verify Deletion with Get
+
+Attempt to retrieve the deleted document. **This step might fail with affected clients due to list handling.**
+
+```tool_code
+# Use the same ID used in Step 11.
+print(default_api.mcp_chroma_test_chroma_get_documents_by_ids(
+    collection_name="mcp_flow_test_coll",
+    ids=["test-doc-2"] # Required list
+))
+```
+
+*Expected Outcome (in affected clients):* Likely failure due to client list handling.
+*Expected Outcome (if successful):* JSON response indicating the document with ID "test-doc-2" was not found (e.g., empty result or specific error).
+
+### 12b. Attempt Get on Non-Existent Document
+
+Attempt to retrieve a document ID that never existed. **This step might fail with affected clients due to list handling.**
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_get_documents_by_ids(
+    collection_name="mcp_flow_test_coll",
+    ids=["this-id-never-existed"] # Required list
+))
+```
+
+*Expected Outcome (in affected clients):* Likely failure due to client list handling.
+*Expected Outcome (if successful):* JSON response indicating document not found.
+
+### 13. Delete Remaining Documents (`test-doc-pangram`, generated IDs)
+
+Delete the other known documents from the first collection.
+
+```tool_code
+# First, delete the pangram doc
+print(default_api.mcp_chroma_test_chroma_delete_document_by_id(
+    collection_name="mcp_flow_test_coll",
+    id="test-doc-pangram" # Single ID
+))
+
+# Need to retrieve IDs of auto-generated docs to delete them
+# For this example, we'll assume we know one from a peek/get_all result
+# Replace 'generated-doc-id-1' with an actual ID obtained from Step 6b
+# print(default_api.mcp_chroma_test_chroma_delete_document_by_id(
+#     collection_name="mcp_flow_test_coll",
+#     id="generated-doc-id-1"
+# ))
+# print(default_api.mcp_chroma_test_chroma_delete_document_by_id(
+#     collection_name="mcp_flow_test_coll",
+#     id="generated-doc-id-2"
+# ))
+```
+
+*Expected Outcome:* Confirmation of delete requests. *Note: Manual step needed to get generated IDs for full cleanup in a real run.*
+
+### 14. Delete First Collection (`mcp_flow_test_coll`)
+
+Clean up by deleting the first test collection.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_delete_collection(collection_name="mcp_flow_test_coll"))
+```
+
+*Expected Outcome:* Confirmation of deletion. If it doesn't exist, an `McpError` is raised.
+
+### 14b. Delete Second Collection (`mcp_flow_test_coll_renamed`)
+
+Clean up by deleting the second (renamed) test collection.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_delete_collection(collection_name="mcp_flow_test_coll_renamed"))
+```
+
+*Expected Outcome:* Confirmation of deletion.
+
+### 15. Verify Collection Deletion
+
+Attempt to list collections (should be empty or only contain non-test collections).
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_list_collections())
+```
+
+**Note:** `name_contains` omitted. Verify manually.
+
+*Expected Outcome:* A list of collection names that does not include `mcp_flow_test_coll` or `mcp_flow_test_coll_renamed`.
+
+---
+
+## Advanced: Thinking Tools (Example Flow)
+
+This section demonstrates a basic workflow using the sequential thinking tools. These tools operate independently of the standard document/collection tools and use their own internal storage mechanisms.
+
+**Note:** These tools manage session state. A `session_id` will be returned on the first call if not provided and should be reused for subsequent calls within the same thinking sequence.
+
+### T1. Start a Thinking Sequence
+
+Record the first thought in a new session.
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_sequential_thinking(
+    thought="Initial idea: Refactor the database schema.",
+    thought_number=1,
+    total_thoughts=3
+    # session_id is omitted, will be generated
+))
+```
+
+*Expected Outcome:* Confirmation, including the generated `session_id`.
+
+### T2. Continue the Sequence
+
+Record the second thought, reusing the `session_id`.
+
+```tool_code
+# Replace 'generated_session_id' with the ID from the previous step's output
+print(default_api.mcp_chroma_test_chroma_sequential_thinking(
+    session_id="generated_session_id",
+    thought="Second step: Identify primary keys and relationships.",
+    thought_number=2,
+    total_thoughts=3
+))
+```
+
+*Expected Outcome:* Confirmation.
+
+### T3. Branch the Thought Process
+
+Create a branch from the first thought to explore an alternative.
+
+```tool_code
+# Replace 'generated_session_id' with the session ID
+print(default_api.mcp_chroma_test_chroma_sequential_thinking(
+    session_id="generated_session_id",
+    thought="Alternative idea: Use a NoSQL approach instead?",
+    thought_number=1, # Start branch numbering from 1
+    total_thoughts=2, # Total thoughts in this branch
+    branch_id="alternative-nosql",
+    branch_from_thought=1 # Branch from the first thought of the main sequence
+))
+```
+
+*Expected Outcome:* Confirmation.
+
+### T4. Get Session Summary
+
+Retrieve all thoughts for the session (optionally including branches).
+
+```tool_code
+# Replace 'generated_session_id' with the session ID
+print(default_api.mcp_chroma_test_chroma_get_session_summary(
+    session_id="generated_session_id",
+    include_branches=True
+))
+```
+
+*Expected Outcome:* A structured summary of thoughts in the session, including the main sequence and the branch.
+
+### T5. Find Similar Thoughts
+
+Search for thoughts similar to a query within the session.
+
+```tool_code
+# Replace 'generated_session_id' with the session ID
+print(default_api.mcp_chroma_test_chroma_find_similar_thoughts(
+    session_id="generated_session_id",
+    query="database design ideas",
+    n_results=3
+))
+```
+
+*Expected Outcome:* A list of thoughts from the session semantically similar to the query.
+
+### T6. Find Similar Sessions
+
+Search for entire sessions similar to a query (across all stored sessions).
+
+```tool_code
+print(default_api.mcp_chroma_test_chroma_find_similar_sessions(
+    query="Schema refactoring discussions",
+    n_results=2
+))
+```
+
+*Expected Outcome:* A list of session IDs and summaries that are semantically similar to the query.
+
+---
+
+This flow covers the primary CRUD operations, filter/query variations, and provides a basic example of the thinking tools. Client limitations with list parameters may still affect query/get operations.

--- a/docs/refactor_plan_mcp_sdk_compliance.md
+++ b/docs/refactor_plan_mcp_sdk_compliance.md
@@ -46,9 +46,6 @@ This is the core phase, modifying how each `_impl` function returns results and 
     - [x] Apply general approach to `_create_collection_impl`.
     - [x] Apply general approach to `_list_collections_impl`.
     - [x] Apply general approach to `_get_collection_impl`.
-    - [x] Apply general approach to `_set_collection_description_impl`.
-    - [x] Apply general approach to `_set_collection_settings_impl`.
-    - [x] Apply general approach to `_update_collection_metadata_impl`.
     - [x] Apply general approach to `_rename_collection_impl`.
     - [x] Apply general approach to `_delete_collection_impl`.
     - [x] Apply general approach to `_peek_collection_impl`.
@@ -104,7 +101,7 @@ This is the core phase, modifying how each `_impl` function returns results and 
   - [ ] Verify successful calls.
   - [ ] Verify expected errors (how does client display `isError=True` result?).
   - [ ] Verify unexpected server errors (protocol-level errors).
-- [ ] **Server Log Verification:** Check log output for clarity and detail.
+- [x] **Server Log Verification:** Check log output for clarity and detail.
 - [x] **Linting/Formatting:** Run tools (`hatch run lint`). (Passed!).
 
 ---

--- a/docs/refactor_plan_mcp_sdk_compliance_v2.md
+++ b/docs/refactor_plan_mcp_sdk_compliance_v2.md
@@ -5,7 +5,8 @@
 1. **Integrating Pydantic** for robust input schema definition and validation.
 2. **Removing unnecessary `Optional` types** in tool inputs where parameters are logically required.
 3. Ensuring **strict standard MCP SDK patterns** are used (no `FastMCP`).
-4. Maintaining the **`isError=True` return pattern** for tool-level errors (established in V1 refactor).
+4. Maintaining the **`McpError` exception pattern** for tool-level errors, letting the server framework handle the conversion to error results.
+5. **Simplifying Document Operations:** Modifying document `add`, `update`, and `delete` tools to handle **single documents** only. This is necessary to improve compatibility with consuming models (LLMs) that struggle with complex list-based inputs for modification operations. Query and get operations will retain their ability to handle multiple items/results.
 
 **Reference:** `docs/mcp-reference.md` (Updated version incorporating Pydantic examples)
 
@@ -20,169 +21,125 @@
   - [x] Ensure a synchronous `main` function exists (or is created) as the primary entry point.
   - [x] Implement/verify argument parsing (e.g., using `click` or `argparse`) for configurations like verbosity.
   - [x] Implement/verify logging configuration:
-    - [x] Set logging level based on verbosity arguments.
-    - [x] Configure `logging.basicConfig` (or equivalent) to output to `sys.stderr`.
-    - [x] Include a clear log format (e.g., timestamp, logger name, level, message).
+  - [x] Set logging level based on verbosity arguments.
+  - [x] Configure `logging.basicConfig` (or equivalent) to output to `sys.stderr`.
+  - [x] Include a clear log format (e.g., timestamp, logger name, level, message).
   - [x] Ensure the main async server setup/run function (e.g., `serve()`) is called using `asyncio.run()`.
   - [x] Include top-level `try...except` block around `asyncio.run()` to catch and log critical startup errors.
 - [x] **Verify `if __name__ == "__main__":`:** Ensure the entry point script correctly calls the `main` function when executed directly.
 
 ---
 
-## Phase 1: Define Pydantic Input Models
+## Phase 1: Define Pydantic Input Models for Simplified/Variant Tools
 
-**Goal:** Create specific Pydantic models for each tool's input arguments.
+**Goal:** Create specific Pydantic models for each tool, simplifying `add`/`update`/`delete` operations to single items and using variants where necessary for `query`/`get`.
 
-- [x] **Review Tool Parameters:** For each tool, identify required vs. truly optional parameters based on ChromaDB's API and the tool's logic.
-- [x] **Create Models:** In a logical location (e.g., within each `tools/` file or a dedicated `schemas.py`), define a Pydantic `BaseModel` for *each* tool.
-  - [x] `collection_tools.py` models (e.g., `CreateCollectionInput`, `ListCollectionsInput`, ...)
-  - [x] `document_tools.py` models (e.g., `AddDocumentsInput`, `QueryDocumentsInput`, ...)
-  - [x] `thinking_tools.py` models (e.g., `SequentialThinkingInput`, `FindSimilarThoughtsInput`, ...)
+- [x] **Identify Tools for Refactoring:** Primarily `document_tools.py` for single-item simplification, and other tools for variant creation if needed to avoid complex optionals.
+- [x] **Define Simplified/Variant Models:**
+  - [ ] `collection_tools.py` variants (e.g., `CreateCollectionInput`, `CreateCollectionWithMetadataInput`).
+  - [x] `document_tools.py`:
+    - **Single-Item Models:** Define models for single-item operations (e.g., `AddDocumentInput`, `AddDocumentWithIdInput`, `AddDocumentWithMetadataInput`, `AddDocumentWithIdAndMetadataInput`, `UpdateDocumentContentInput`, `UpdateDocumentMetadataInput`, `DeleteDocumentByIdInput`). These models will have fields like `document: str`, `id: str`, `metadata: str` or `metadata: Dict` instead of lists.
+    - **List-Based Query/Get Variants:** Define specific variants for query and get operations that still need lists (e.g., `QueryDocumentsInput`, `QueryDocumentsWithWhereFilterInput`, `GetDocumentsByIdsInput`, `GetAllDocumentsInput`). These models will use `query_texts: List[str]`, `ids: List[str]`, etc.
+  - [x] `thinking_tools.py` variants (e.g., `SequentialThinkingInput`, `SequentialThinkingWithDataInput`).
 - [x] **Define Fields:**
-  - [x] Use precise Python types (`str`, `int`, `float`, `list`, `dict`, `bool`).
-  - [x] **Minimize `Optional`:** Only use `Optional[T]` (or `T | None`) if the parameter is *truly optional* for the tool's operation. If a parameter is required by the logic or Chroma, make it non-optional in the model. Pydantic validation will enforce its presence.
-  - [x] Use `pydantic.Field` to add descriptions, default values (for optional fields), and constraints if applicable.
+  - [x] Use precise Python types (`str`, `int`, `float`, `List`, `Dict`, `bool`).
+  - [x] **Simplify Add/Update/Delete:** Ensure models for these operations use singular types (`str`, `Dict`) instead of `List`.
+  - [x] **Eliminate Complex Optionals:** Avoid `Optional[Dict[...]]` or `Optional[List[...]]` in *all* models, using specific required fields or variants instead. Simple `Optional`s (`Optional[str]`) are acceptable if needed.
+  - [x] Use `pydantic.Field` for descriptions/constraints.
 
 ---
 
 ## Phase 2: Update Tool Registration (`list_tools`)
 
-**Goal:** Use the new Pydantic models to generate the `inputSchema` for tool registration.
+**Goal:** Register the simplified single-item tools and necessary variants, removing original list-based modification tools.
 
-- [x] **Import Models:** Ensure Pydantic models are imported into the file where tools are registered (likely `src/chroma_mcp/server.py` or similar).
-- [x] **Update `Tool` Definitions:** Modify the list of `mcp.types.Tool` objects:
-  - [x] For each tool, set `inputSchema=YourCorrespondingInputModel.model_json_schema()` (assuming Pydantic v2+).
-  - [x] Verify tool `name` and `description` remain accurate.
+- [x] **Import New Models:** Ensure the new Pydantic models (single-item and variant) are imported into `src/chroma_mcp/server.py`.
+- [x] **Update `Tool` Definitions:** Modify the list of `mcp.types.Tool` objects in the `list_tools` function:
+  - [x] **Remove Original List-Based Tools:** Comment out or delete registrations for original tools being replaced (e.g., the original list-based `chroma_add_documents`, `chroma_update_documents`, `chroma_delete_documents`).
+  - [x] **Register Simplified/Variant Tools:** Add new `mcp.types.Tool` registration entries for each simplified single-item tool and each required variant defined in Phase 1.
+  - Set the `name` (e.g., `chroma_add_document_with_id`, `chroma_query_documents_with_where_filter`).
+  - Set the `description` clearly indicating the specific action (single item or variant).
+  - Set the `inputSchema` using the corresponding Pydantic model.
+- [x] **Update `TOOL_NAMES`, `INPUT_MODELS`, `IMPL_FUNCTIONS` Mappings:** Add entries for all new tools and remove entries for the replaced original tools in `src/chroma_mcp/server.py`.
+
+**Tools to Replace/Refactor:**
+
+- `chroma_create_collection` -> Add `chroma_create_collection_with_metadata`
+- `chroma_add_documents` -> Replace with **single-item** tools: `add_document`, `add_document_with_id`, `add_document_with_metadata`, `add_document_with_id_and_metadata`.
+- `chroma_query_documents` -> Replace with **list-based variants**: `query_documents`, `query_documents_with_where_filter`, `query_documents_with_document_filter`.
+- `chroma_get_documents` -> Replace with **list-based variants**: `get_documents_by_ids`, `get_documents_with_where_filter`, `get_documents_with_document_filter`, `get_all_documents`.
+- `chroma_update_documents` -> Replace with **single-item** tools: `update_document_content`, `update_document_metadata`.
+- `chroma_delete_documents` -> Replace with **single-item** tool `delete_document_by_id` and **filter-based variants** `delete_documents_by_where_filter`, `delete_documents_by_document_filter`.
+- `chroma_sequential_thinking` -> Add `chroma_sequential_thinking_with_data`
 
 ---
 
 ## Phase 3: Refactor Tool Implementation (Dispatch/Handler)
 
-**Goal:** Implement Pydantic validation at the entry point of tool execution and pass validated data to core logic.
+**Goal:** Ensure the dispatcher correctly routes calls for the new simplified/variant tools to their implementations.
 
-- [x] **Identify Handler:** Locate the central function that receives the `tool_name` and `arguments: dict` (e.g., the function decorated with `@server.call_tool()` in `src/chroma_mcp/server.py`).
-- [x] **Implement Validation Logic:** Within this handler, *before* calling the core logic for each tool:
-  - [x] Use a `try...except pydantic.ValidationError` block.
-  - [x] Inside the `try`, instantiate the appropriate Pydantic input model: `input_data = ToolInputModel(**arguments)`.
-  - [x] If validation fails (`except ValidationError as e`):
-  - [x] Log the validation error (e.g., `logger.warning(f"Input validation failed for {tool_name}: {e}")`).
-  - [x] **Return** `types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Input Error: {str(e)}")])`.
-- [x] **Pass Validated Data:** Modify the call to the core logic function to pass the `input_data` (the Pydantic model instance) instead of the raw `arguments` dict.
-- [x] **Handle Execution Errors:** Keep the *outer* `try...except Exception` block (established in V1 refactor) around the validation *and* core logic call to catch errors *after* validation, returning `CallToolResult(isError=True, ...)` for these execution failures.
-
-**Example Snippet (Conceptual):**
-
-```python
-# Inside the @mcp.server.call_tool() decorated function
-async def call_tool(name: str, arguments: dict) -> types.CallToolResult:
-    try:
-        # --- Pydantic Validation --- >
-        validated_input = None
-        if name == "create_collection":
-            InputModel = CreateCollectionInput
-        elif name == "add_documents":
-            InputModel = AddDocumentsInput
-        # ... other tools
-        else:
-            # Handle unknown tool name early
-            logger.error(f"Attempted to call unknown tool: {name}")
-            return types.CallToolResult(
-                isError=True,
-                content=[types.TextContent(type="text", text=f"Tool Error: Unknown tool name '{name}'")]
-            )
-
-        try:
-            validated_input = InputModel(**arguments)
-        except ValidationError as e:
-            logger.warning(f"Input validation failed for {name}: {e}")
-            # Return validation error details to the client
-            return types.CallToolResult(
-                isError=True,
-                content=[types.TextContent(type="text", text=f"Input Error: {str(e)}")]
-            )
-        # <--- Pydantic Validation Done ---
-
-        # --- Call Core Logic --- >
-        # Find and call the corresponding implementation function
-        # (These functions now expect the Pydantic model instance)
-        if name == "create_collection":
-            result = await _create_collection_impl(validated_input)
-        elif name == "add_documents":
-            result = await _add_documents_impl(validated_input)
-        # ... etc.
-
-        # Return the result from the _impl function (already a CallToolResult)
-        return result
-
-    except Exception as error:
-        # Catch errors during core logic execution (post-validation)
-        logger.error(f"Execution failed for tool {name}: {error}", exc_info=True)
-        return types.CallToolResult(
-            isError=True,
-            content=[types.TextContent(type="text", text=f"Tool Execution Error: {str(error)}")]
-        )
-```
+- [x] **Identify Handler:** Locate the central function decorated with `@server.call_tool()` (`call_tool` in `src/chroma_mcp/server.py`).
+- [x] **Update Dispatch Logic:** The existing logic using `INPUT_MODELS` and `IMPL_FUNCTIONS` dictionaries should work correctly, provided these dictionaries are updated accurately in Phase 2.
+- [x] **Error Handling:** The existing `try...except ValidationError` and the raising of `McpError` remain appropriate.
 
 ---
 
 ## Phase 4: Refactor Core Logic Functions (`_impl`)
 
-**Goal:** Simplify core logic functions by having them accept the validated Pydantic model.
+**Goal:** Create or adapt `_impl` functions for each simplified single-item tool and list-based variant.
 
-- [x] **Update Signatures:** Change the signature of each `_impl` function (or equivalent) to accept the specific Pydantic input model instance instead of `arguments: dict`.
-  - [x] `collection_tools.py` `_impl` functions.
-  - [x] `document_tools.py` `_impl` functions.
-  - [x] `thinking_tools.py` `_impl` functions.
-- [x] **Update Parameter Access:** Replace dictionary access (e.g., `arguments.get("param")`, `arguments["param"]`) with direct attribute access on the input model instance (e.g., `input_data.param`).
-- [x] **Remove Redundant Checks:** Remove checks for `None` or key existence for parameters that are now non-optional in the Pydantic model, as validation guarantees their presence and type.
-- [x] **Maintain `isError=True` Returns:** Ensure these functions still return `CallToolResult` and handle their *own* execution errors (e.g., Chroma API errors) by catching them and returning `CallToolResult(isError=True, ...)`, as established in V1.
+- [x] **Create/Adapt `_impl` Functions:** Define/modify implementation functions (e.g., `_add_document_with_id_impl`, `_query_documents_with_where_filter_impl`) for each tool registered in Phase 2.
+- [x] **Update Signatures:** Ensure each `_impl` function accepts its specific Pydantic model (e.g., `input_data: AddDocumentWithIdInput`, `input_data: QueryDocumentsWithWhereFilterInput`) and returns `List[types.TextContent]`.
+- [x] **Implement Logic:**
+  - **Single-Item Tools:** Logic will take single inputs (e.g., `input_data.id`, `input_data.document`). When calling the underlying ChromaDB client method that expects lists, wrap the single item in a list (e.g., `collection.add(ids=[input_data.id], documents=[input_data.document], ...)`).
+  - **List-Based Variants:** Logic will handle lists directly from the input model (e.g., `input_data.query_texts`).
+  - Consider shared internal helpers where appropriate.
+- [x] **Raise `McpError` on Failure:** Ensure functions catch operational errors and raise `McpError`.
 
 ---
 
 ## Phase 5: Refactor Utility Functions
 
-**Goal:** Review and potentially simplify error utility functions.
+**Goal:** Review utility functions in light of the new structure.
 
-- [x] **`src/chroma_mcp/utils/errors.py`:**
-  - [x] Review `handle_chroma_error`: This might still be useful within `_impl` functions to specifically catch ChromaDB exceptions and format them into the `isError=True` `CallToolResult`, but it should *not* be raising `McpError` for expected operational errors.
-  - [x] Review `raise_validation_error`: This function is likely **obsolete** if all input validation is handled by Pydantic models in the dispatcher (Phase 3). Consider removing it. (Removed `validate_input` function which served this purpose)
+- [x] **`src/chroma_mcp/utils/errors.py`:** No changes likely needed beyond Phase V1/V2 adjustments. `handle_chroma_error` can still be used to convert Chroma errors to `McpError` within `_impl` functions.
+- [ ] **Shared Logic Helpers:** Consider creating new utility functions if significant logic is shared between the new `_impl` variants (as mentioned in Phase 4).
 
 ---
 
 ## Phase 6: Update Tests
 
-**Goal:** Align tests with Pydantic validation and the refactored function signatures.
+**Goal:** Align tests with the new single-item add/update/delete tools, list-based query/get tools, and `McpError` exception handling.
 
 **General Approach Checklist for Tests:**
 
-- [x] **Update Fixtures/Inputs:** Ensure test inputs match the Pydantic models (provide required fields, use correct types, remove `None` for non-optional fields).
-- [x] **Add Validation Failure Tests:** Create new tests specifically designed to fail Pydantic validation (e.g., missing required args, incorrect types) and assert that the handler correctly returns `CallToolResult(isError=True, ...)` with an appropriate validation error message.
-- [x] **Update Existing Error Tests:** Tests previously checking for `McpError` on bad input should be updated to check for `CallToolResult(isError=True, ...)` resulting from `ValidationError`.
-- [x] **Update Core Logic Tests:** If testing `_impl` functions directly, update mocks/inputs to pass the Pydantic model instance instead of a dictionary.
-- [x] **Maintain Execution Error Tests:** Keep tests that verify `CallToolResult(isError=True, ...)` is returned for errors *after* successful validation (e.g., mocking a Chroma API error).
-- [x] **Maintain Success Case Tests:** Ensure success cases still pass, checking the `content` of the returned `CallToolResult`.
+- [x] **Write Tests for New Tools:** Create new test functions for each specific tool (single-item or variant) added in Phase 2 (e.g., `test_add_document_with_id_success`, `test_query_documents_with_where_filter_success`).
+  - Use inputs matching the tool's Pydantic model.
+  - Test validation failures by providing incorrect input to `call_tool` and asserting `pytest.raises(McpError, code=INVALID_PARAMS)`.
+  - Test execution failures by mocking errors and asserting `_impl` raises `McpError`.
+  - Test success cases.
+- [x] **Remove/Skip Tests for Replaced Tools:** Remove or skip tests for the original list-based tools that were replaced.
 
 **Specific Test Modules:**
 
-- [x] **`tests/tools/test_collection_tools.py`:** Update all tests.
-- [x] **`tests/tools/test_document_tools.py`:** Update all tests.
-- [x] **`tests/tools/test_thinking_tools.py`:** Update all tests.
+- [ ] **`tests/tools/test_collection_tools.py`:** Add tests for `create_collection_with_metadata`.
+- [x] **`tests/tools/test_document_tools.py`:** Add tests for all **single-item** `add`, `update`, `delete` tools and **list-based** `query`, `get`, filter-delete variants. Skip/remove tests for original list-based modification tools.
+- [x] **`tests/tools/test_thinking_tools.py`:** Add tests for `sequential_thinking_with_data`.
 
 ---
 
 ## Phase 7: Review and Verification
 
-**Goal:** Ensure the refactoring is complete, correct, and improves compatibility.
+**Goal:** Ensure the refactoring is complete, correct, and improves client compatibility by using single-item modification tools.
 
-- [x] **Code Review:** Perform a thorough review focusing on Pydantic usage, removal of Optionals, error handling consistency, and adherence to `mcp-reference.md`. (Reviewed `list_tools` and `call_tool`)
-- [x] **Run Tests:** Execute the full test suite (`hatch run test`). Address any failures. (Test suite successfully executed via `./scripts/test.sh`, all tests passed or skipped as expected).
-- [ ] **Manual Testing (MCP Inspector):**
-  - [x] Test valid inputs for all tools.
-  - [x] Test invalid inputs (missing required fields, wrong types) and verify clear `Input Error:` messages are returned via `isError=True`.
-  - [ ] Test scenarios causing execution errors (e.g., deleting a non-existent collection) and verify `Tool Execution Error:` messages via `isError=True`.
-- [ ] **Manual Testing (Integrated Clients - Cursor, etc.):**
-  - [x] Verify successful tool calls work as expected.
-  - [x] Observe how clients handle the `isError=True` results for both validation and execution errors. Does the feedback help the user/LLM?
-  - [ ] Test scenarios where optional parameters are omitted and provided.
-- [x] **Server Log Verification:** Check logs for clarity, especially for validation failures vs. execution errors.
-- [x] **Linting/Formatting:** Run tools (`hatch run lint`). (`black` successful, `pylint` skipped)
+- [x] **Code Review:** Perform a thorough review focusing on the single-item tools, list-based variants, Pydantic models, `_impl` logic (especially list wrapping for single-item calls), `McpError` usage, and test coverage.
+- [x] **Run Tests:** Execute the full test suite (`hatch run test`). Address any failures.
+- [ ] **Manual Testing (MCP Inspector / Client):**
+  - [ ] Verify the *original list-based* add/update/delete tools no longer appear.
+  - [ ] Verify the *new single-item* add/update/delete tools appear correctly.
+  - [ ] Verify the *new list-based* query/get variants appear correctly.
+  - [ ] Test valid inputs for all *new* tools.
+  - [ ] Test invalid inputs for tools (e.g., missing required fields) and verify `McpError` (`INVALID_PARAMS`).
+  - [ ] Test execution errors and verify `McpError`.
+- [x] **Server Log Verification:** Check logs.
+- [ ] **Linting/Formatting:** Run tools (`hatch run lint`).

--- a/examples/simple_client.py
+++ b/examples/simple_client.py
@@ -28,57 +28,53 @@ except ImportError:
     sys.exit(1)
 
 # Path to the runner script
-server_script = os.path.join(parent_dir, 'run_chroma_mcp.py')
+server_script = os.path.join(parent_dir, "run_chroma_mcp.py")
 
 # Use the current Python executable
 PYTHON_EXECUTABLE = sys.executable
+
 
 async def main():
     """Run a simple demo of Chroma MCP server capabilities."""
     print("Starting Chroma MCP Client Demo")
     print(f"Using server script at: {server_script}")
-    
+
     # Create the async exit stack for resource cleanup
     exit_stack = AsyncExitStack()
-    
+
     try:
         # Set up server parameters
         server_params = StdioServerParameters(
-            command=PYTHON_EXECUTABLE,
-            args=[server_script],
-            env={
-                "PYTHONUNBUFFERED": "1",
-                "PYTHONIOENCODING": "utf-8"
-            }
+            command=PYTHON_EXECUTABLE, args=[server_script], env={"PYTHONUNBUFFERED": "1", "PYTHONIOENCODING": "utf-8"}
         )
-        
+
         print("Connecting to server...")
-        
+
         # Connect to the server
         stdio_transport = await exit_stack.enter_async_context(stdio_client(server_params))
         stdio, write = stdio_transport
-        
+
         # Create a client session
         session = await exit_stack.enter_async_context(ClientSession(stdio, write))
-        
+
         # Initialize the session
         print("Initializing session...")
         await session.initialize()
-        
+
         # List available tools
         print("Listing available tools...")
         response = await session.list_tools()
         tools = response.tools
         print(f"Found {len(tools)} available tools: {[tool.name for tool in tools]}")
-        
+
         # Create a test collection
         collection_name = "demo_collection"
         print(f"\nCreating collection: {collection_name}")
         try:
-            create_result = await session.call_tool("chroma_create_collection", {
-                "collection_name": collection_name,
-                "description": "A demo collection for testing"
-            })
+            create_result = await session.call_tool(
+                "chroma_create_collection",
+                {"collection_name": collection_name, "description": "A demo collection for testing"},
+            )
             for content in create_result.content:
                 print(f"Collection created: {content.text}")
                 collection_info = json.loads(content.text)
@@ -86,56 +82,58 @@ async def main():
         except Exception as e:
             print(f"Error creating collection: {e}")
             print("Continuing with existing collection...")
-            
+
         # Add documents to the collection
         test_documents = [
             "The Chroma MCP Server provides a standardized interface for vector databases.",
             "ChromaDB is an open-source embedding database for AI applications.",
             "Vector databases are optimized for storing and searching high-dimensional vectors.",
-            "Semantic search allows finding documents based on meaning rather than keywords."
+            "Semantic search allows finding documents based on meaning rather than keywords.",
         ]
-        
+
         print(f"\nAdding {len(test_documents)} documents to collection...")
-        add_result = await session.call_tool("chroma_add_documents", {
-            "collection_name": collection_name,
-            "documents": test_documents
-        })
+        add_result = await session.call_tool(
+            "chroma_add_documents", {"collection_name": collection_name, "documents": test_documents}
+        )
         for content in add_result.content:
             print(f"Documents added: {content.text}")
-        
+
         # Query the collection
         query = "vector database for AI"
         print(f"\nQuerying collection with: '{query}'")
-        query_result = await session.call_tool("chroma_query_documents", {
-            "collection_name": collection_name,
-            "query_texts": [query],
-            "n_results": 2,
-            "include": ["documents", "distances"]
-        })
+        query_result = await session.call_tool(
+            "chroma_query_documents",
+            {
+                "collection_name": collection_name,
+                "query_texts": [query],
+                "n_results": 2,
+                "include": ["documents", "distances"],
+            },
+        )
         for content in query_result.content:
             results = json.loads(content.text)
             print("\nQuery results:")
             for i, (doc, dist) in enumerate(zip(results["documents"][0], results["distances"][0])):
                 print(f"{i+1}. [{dist:.4f}] {doc}")
-        
+
         # Clean up (optional)
         print("\nDemo completed. Delete the test collection? (y/n)")
-        if input().lower() == 'y':
-            delete_result = await session.call_tool("chroma_delete_collection", {
-                "collection_name": collection_name
-            })
+        if input().lower() == "y":
+            delete_result = await session.call_tool("chroma_delete_collection", {"collection_name": collection_name})
             for content in delete_result.content:
                 print(f"Collection deleted: {content.text}")
-        
+
     except Exception as e:
         print(f"\nError during demo: {e}")
         import traceback
+
         traceback.print_exc()
     finally:
         # Clean up resources
         await exit_stack.aclose()
         print("\nDemo finished.")
 
+
 if __name__ == "__main__":
     # Run the demo
-    asyncio.run(main()) 
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chroma-mcp-server"
-version = "0.1.82"
+version = "0.1.84"
 description = "Chroma MCP Server - Vector Database Integration for LLM Applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chroma-mcp-server"
-version = "0.1.65"
+version = "0.1.82"
 description = "Chroma MCP Server - Vector Database Integration for LLM Applications"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -34,13 +34,13 @@ dependencies = [
     "fastmcp>=0.4.1",
     # These are needed by our code directly
     "numpy>=2.2.0",  # For numpy arrays in handlers
+    # For embeddings generation
+    "onnxruntime>=1.21.0",
 ]
 
 [project.optional-dependencies]
 # Optional dependencies for extended functionality
 full = [
-    # For embeddings generation
-    "onnxruntime>=1.21.0",
     "sentence-transformers>=4.0.1",
     # Only needed if using HTTP client
     "httpx>=0.28.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,6 +19,10 @@ fi
 echo "Cleaning previous builds..."
 rm -rf dist/ build/ *.egg-info
 
+# Format code before building
+echo "Formatting code with Black via Hatch..."
+hatch run black .
+
 # Build the package
 echo "Building package with Hatch..."
 hatch build

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -173,7 +173,11 @@ fi
 
 # Clean previous builds
 echo "Cleaning previous builds..."
-rm -rf "$DIST_DIR" "$BUILD_DIR" $EGG_INFO_DIR 
+rm -rf "$DIST_DIR" "$BUILD_DIR" $EGG_INFO_DIR
+
+# Format code before building
+echo "Formatting code with Black via Hatch (from project root)..."
+(cd "$PROJECT_ROOT" && hatch run black .)
 
 # Build the package using project root context
 echo "Building package with Hatch (from project root)..."

--- a/src/chroma_mcp/__init__.py
+++ b/src/chroma_mcp/__init__.py
@@ -13,32 +13,11 @@ from .utils import (
     errors,
 )
 
-# from .handlers import (
-#     CollectionHandler,
-#     DocumentHandler,
-#     ThinkingHandler
-# )
 from .tools import collection_tools, document_tools, thinking_tools
-
-# Only import get_mcp from server
-# from .server import get_mcp
-# Removed: main, config_server, create_parser
-# from .server import (
-#     main,
-#     config_server,
-#     create_parser,
-#     get_mcp
-# )
 
 # Import key components for easier access from outside
 from .utils import get_logger, get_chroma_client, get_embedding_function
 from .utils.errors import McpError, ValidationError  # Assuming McpError is defined here or imported
-
-# REMOVE this line as get_mcp no longer exists in server.py
-# from .server import get_mcp
-
-# Optionally import the app instance if needed globally (use with caution)
-# from .app import mcp
 
 __version__ = "0.1.0"
 
@@ -48,10 +27,6 @@ __all__ = [
     # Types
     "DocumentMetadata",
     "ThoughtMetadata",
-    # Handlers - Removed
-    # "CollectionHandler",
-    # "DocumentHandler",
-    # "ThinkingHandler",
     # Utils
     "config",
     "client",
@@ -61,9 +36,6 @@ __all__ = [
     "document_tools",
     "thinking_tools",
     # Server - Only expose get_mcp
-    # "main", # Removed
-    # "config_server", # Removed
-    # "create_parser", # Removed
     "get_mcp",
     # Version
     "__version__",

--- a/src/chroma_mcp/cli.py
+++ b/src/chroma_mcp/cli.py
@@ -111,11 +111,10 @@ def main() -> int:
         return server_main()
     except KeyboardInterrupt:
         print("Server stopped by user", file=sys.stderr)
+        return 0
     except Exception as e:
         print(f"Error running server: {e}", file=sys.stderr)
         return 1
-
-    return 0
 
 
 if __name__ == "__main__":

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -46,24 +46,32 @@ from mcp import types  # Import base MCP types
 # Import all Pydantic input models
 from .tools.collection_tools import (
     CreateCollectionInput,
+    CreateCollectionWithMetadataInput,
     ListCollectionsInput,
     GetCollectionInput,
-    SetCollectionDescriptionInput,
-    SetCollectionSettingsInput,
-    UpdateCollectionMetadataInput,
     RenameCollectionInput,
     DeleteCollectionInput,
     PeekCollectionInput,
 )
 from .tools.document_tools import (
-    AddDocumentsInput,
+    AddDocumentInput,
+    AddDocumentWithIDInput,
+    AddDocumentWithMetadataInput,
+    AddDocumentWithIDAndMetadataInput,
     QueryDocumentsInput,
-    GetDocumentsInput,
-    UpdateDocumentsInput,
-    DeleteDocumentsInput,
+    QueryDocumentsWithWhereFilterInput,
+    QueryDocumentsWithDocumentFilterInput,
+    GetDocumentsByIdsInput,
+    GetDocumentsWithWhereFilterInput,
+    GetDocumentsWithDocumentFilterInput,
+    GetAllDocumentsInput,
+    UpdateDocumentContentInput,
+    UpdateDocumentMetadataInput,
+    DeleteDocumentByIdInput,
 )
 from .tools.thinking_tools import (
     SequentialThinkingInput,
+    SequentialThinkingWithCustomDataInput,
     FindSimilarThoughtsInput,
     GetSessionSummaryInput,
     FindSimilarSessionsInput,
@@ -72,24 +80,32 @@ from .tools.thinking_tools import (
 # Import all _impl functions
 from .tools.collection_tools import (
     _create_collection_impl,
+    _create_collection_with_metadata_impl,
     _list_collections_impl,
     _get_collection_impl,
-    _set_collection_description_impl,
-    _set_collection_settings_impl,
-    _update_collection_metadata_impl,
     _rename_collection_impl,
     _delete_collection_impl,
     _peek_collection_impl,
 )
 from .tools.document_tools import (
-    _add_documents_impl,
+    _add_document_impl,
+    _add_document_with_id_impl,
+    _add_document_with_metadata_impl,
+    _add_document_with_id_and_metadata_impl,
     _query_documents_impl,
-    _get_documents_impl,
-    _update_documents_impl,
-    _delete_documents_impl,
+    _query_documents_with_where_filter_impl,
+    _query_documents_with_document_filter_impl,
+    _get_documents_by_ids_impl,
+    _get_documents_with_where_filter_impl,
+    _get_documents_with_document_filter_impl,
+    _get_all_documents_impl,
+    _update_document_content_impl,
+    _update_document_metadata_impl,
+    _delete_document_by_id_impl,
 )
 from .tools.thinking_tools import (
     _sequential_thinking_impl,
+    _sequential_thinking_with_custom_data_impl,
     _find_similar_thoughts_impl,
     _get_session_summary_impl,
     _find_similar_sessions_impl,
@@ -244,70 +260,94 @@ def config_server(args: argparse.Namespace) -> None:
 # Tool names dictionary for consistency
 TOOL_NAMES = {
     "CREATE_COLLECTION": "chroma_create_collection",
+    "CREATE_COLLECTION_WITH_META": "chroma_create_collection_with_metadata",
     "LIST_COLLECTIONS": "chroma_list_collections",
     "GET_COLLECTION": "chroma_get_collection",
-    "SET_COLLECTION_DESC": "chroma_set_collection_description",
-    "SET_COLLECTION_SETTINGS": "chroma_set_collection_settings",
-    "UPDATE_COLLECTION_META": "chroma_update_collection_metadata",
     "RENAME_COLLECTION": "chroma_rename_collection",
     "DELETE_COLLECTION": "chroma_delete_collection",
     "PEEK_COLLECTION": "chroma_peek_collection",
-    "ADD_DOCS": "chroma_add_documents",
+    "ADD_DOCS": "chroma_add_document",
+    "ADD_DOCS_IDS": "chroma_add_document_with_id",
+    "ADD_DOCS_META": "chroma_add_document_with_metadata",
+    "ADD_DOCS_IDS_META": "chroma_add_document_with_id_and_metadata",
     "QUERY_DOCS": "chroma_query_documents",
-    "GET_DOCS": "chroma_get_documents",
-    "UPDATE_DOCS": "chroma_update_documents",
-    "DELETE_DOCS": "chroma_delete_documents",
+    "QUERY_DOCS_WHERE": "chroma_query_documents_with_where_filter",
+    "QUERY_DOCS_DOC": "chroma_query_documents_with_document_filter",
+    "GET_DOCS_IDS": "chroma_get_documents_by_ids",
+    "GET_DOCS_WHERE": "chroma_get_documents_with_where_filter",
+    "GET_DOCS_DOC": "chroma_get_documents_with_document_filter",
+    "GET_DOCS_ALL": "chroma_get_all_documents",
+    "DELETE_DOCS": "chroma_delete_document_by_id",
     "SEQ_THINKING": "chroma_sequential_thinking",
+    "SEQ_THINKING_CUSTOM": "chroma_sequential_thinking_with_custom_data",
     "FIND_THOUGHTS": "chroma_find_similar_thoughts",
     "GET_SUMMARY": "chroma_get_session_summary",
     "FIND_SESSIONS": "chroma_find_similar_sessions",
     "GET_VERSION": "chroma_get_server_version",
+    "UPDATE_DOC_CONTENT": "chroma_update_document_content",
+    "UPDATE_DOC_META": "chroma_update_document_metadata",
 }
 
 # Pydantic models mapping
 INPUT_MODELS = {
     TOOL_NAMES["CREATE_COLLECTION"]: CreateCollectionInput,
+    TOOL_NAMES["CREATE_COLLECTION_WITH_META"]: CreateCollectionWithMetadataInput,
     TOOL_NAMES["LIST_COLLECTIONS"]: ListCollectionsInput,
     TOOL_NAMES["GET_COLLECTION"]: GetCollectionInput,
-    TOOL_NAMES["SET_COLLECTION_DESC"]: SetCollectionDescriptionInput,
-    TOOL_NAMES["SET_COLLECTION_SETTINGS"]: SetCollectionSettingsInput,
-    TOOL_NAMES["UPDATE_COLLECTION_META"]: UpdateCollectionMetadataInput,
     TOOL_NAMES["RENAME_COLLECTION"]: RenameCollectionInput,
     TOOL_NAMES["DELETE_COLLECTION"]: DeleteCollectionInput,
     TOOL_NAMES["PEEK_COLLECTION"]: PeekCollectionInput,
-    TOOL_NAMES["ADD_DOCS"]: AddDocumentsInput,
+    TOOL_NAMES["ADD_DOCS"]: AddDocumentInput,
+    TOOL_NAMES["ADD_DOCS_IDS"]: AddDocumentWithIDInput,
+    TOOL_NAMES["ADD_DOCS_META"]: AddDocumentWithMetadataInput,
+    TOOL_NAMES["ADD_DOCS_IDS_META"]: AddDocumentWithIDAndMetadataInput,
     TOOL_NAMES["QUERY_DOCS"]: QueryDocumentsInput,
-    TOOL_NAMES["GET_DOCS"]: GetDocumentsInput,
-    TOOL_NAMES["UPDATE_DOCS"]: UpdateDocumentsInput,
-    TOOL_NAMES["DELETE_DOCS"]: DeleteDocumentsInput,
+    TOOL_NAMES["QUERY_DOCS_WHERE"]: QueryDocumentsWithWhereFilterInput,
+    TOOL_NAMES["QUERY_DOCS_DOC"]: QueryDocumentsWithDocumentFilterInput,
+    TOOL_NAMES["GET_DOCS_IDS"]: GetDocumentsByIdsInput,
+    TOOL_NAMES["GET_DOCS_WHERE"]: GetDocumentsWithWhereFilterInput,
+    TOOL_NAMES["GET_DOCS_DOC"]: GetDocumentsWithDocumentFilterInput,
+    TOOL_NAMES["GET_DOCS_ALL"]: GetAllDocumentsInput,
+    TOOL_NAMES["DELETE_DOCS"]: DeleteDocumentByIdInput,
     TOOL_NAMES["SEQ_THINKING"]: SequentialThinkingInput,
+    TOOL_NAMES["SEQ_THINKING_CUSTOM"]: SequentialThinkingWithCustomDataInput,
     TOOL_NAMES["FIND_THOUGHTS"]: FindSimilarThoughtsInput,
     TOOL_NAMES["GET_SUMMARY"]: GetSessionSummaryInput,
     TOOL_NAMES["FIND_SESSIONS"]: FindSimilarSessionsInput,
-    # GET_VERSION has no input model
+    TOOL_NAMES["UPDATE_DOC_CONTENT"]: UpdateDocumentContentInput,
+    TOOL_NAMES["UPDATE_DOC_META"]: UpdateDocumentMetadataInput,
+    TOOL_NAMES["GET_VERSION"]: None,  # GET_VERSION has no input model
 }
 
 # Tool implementation function mapping
 IMPL_FUNCTIONS = {
     TOOL_NAMES["CREATE_COLLECTION"]: _create_collection_impl,
+    TOOL_NAMES["CREATE_COLLECTION_WITH_META"]: _create_collection_with_metadata_impl,
     TOOL_NAMES["LIST_COLLECTIONS"]: _list_collections_impl,
     TOOL_NAMES["GET_COLLECTION"]: _get_collection_impl,
-    TOOL_NAMES["SET_COLLECTION_DESC"]: _set_collection_description_impl,
-    TOOL_NAMES["SET_COLLECTION_SETTINGS"]: _set_collection_settings_impl,
-    TOOL_NAMES["UPDATE_COLLECTION_META"]: _update_collection_metadata_impl,
     TOOL_NAMES["RENAME_COLLECTION"]: _rename_collection_impl,
     TOOL_NAMES["DELETE_COLLECTION"]: _delete_collection_impl,
     TOOL_NAMES["PEEK_COLLECTION"]: _peek_collection_impl,
-    TOOL_NAMES["ADD_DOCS"]: _add_documents_impl,
+    TOOL_NAMES["ADD_DOCS"]: _add_document_impl,
+    TOOL_NAMES["ADD_DOCS_IDS"]: _add_document_with_id_impl,
+    TOOL_NAMES["ADD_DOCS_META"]: _add_document_with_metadata_impl,
+    TOOL_NAMES["ADD_DOCS_IDS_META"]: _add_document_with_id_and_metadata_impl,
     TOOL_NAMES["QUERY_DOCS"]: _query_documents_impl,
-    TOOL_NAMES["GET_DOCS"]: _get_documents_impl,
-    TOOL_NAMES["UPDATE_DOCS"]: _update_documents_impl,
-    TOOL_NAMES["DELETE_DOCS"]: _delete_documents_impl,
+    TOOL_NAMES["QUERY_DOCS_WHERE"]: _query_documents_with_where_filter_impl,
+    TOOL_NAMES["QUERY_DOCS_DOC"]: _query_documents_with_document_filter_impl,
+    TOOL_NAMES["GET_DOCS_IDS"]: _get_documents_by_ids_impl,
+    TOOL_NAMES["GET_DOCS_WHERE"]: _get_documents_with_where_filter_impl,
+    TOOL_NAMES["GET_DOCS_DOC"]: _get_documents_with_document_filter_impl,
+    TOOL_NAMES["GET_DOCS_ALL"]: _get_all_documents_impl,
+    TOOL_NAMES["DELETE_DOCS"]: _delete_document_by_id_impl,
     TOOL_NAMES["SEQ_THINKING"]: _sequential_thinking_impl,
+    TOOL_NAMES["SEQ_THINKING_CUSTOM"]: _sequential_thinking_with_custom_data_impl,
     TOOL_NAMES["FIND_THOUGHTS"]: _find_similar_thoughts_impl,
     TOOL_NAMES["GET_SUMMARY"]: _get_session_summary_impl,
     TOOL_NAMES["FIND_SESSIONS"]: _find_similar_sessions_impl,
-    # GET_VERSION needs a simple handler
+    TOOL_NAMES["UPDATE_DOC_CONTENT"]: _update_document_content_impl,
+    TOOL_NAMES["UPDATE_DOC_META"]: _update_document_metadata_impl,
+    TOOL_NAMES["GET_VERSION"]: None,  # GET_VERSION needs a simple handler
 }
 
 
@@ -320,9 +360,18 @@ async def list_tools() -> List[types.Tool]:
         # Collection Tools
         types.Tool(
             name=TOOL_NAMES["CREATE_COLLECTION"],
-            description="Create a new ChromaDB collection with specific or default settings. If `metadata` is provided, it overrides the default settings (e.g., HNSW parameters). If `metadata` is None or omitted, default settings are used. Use other tools like 'set_collection_description' to modify mutable metadata later.",
+            description="Create a new ChromaDB collection using server default settings.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["CREATE_COLLECTION"]].model_json_schema(),
         ),
+        # --- Re-enable the metadata tool --- #
+        types.Tool(
+            name=TOOL_NAMES["CREATE_COLLECTION_WITH_META"],
+            description="Create a new ChromaDB collection with specific metadata/settings provided (as JSON string).",
+            inputSchema=INPUT_MODELS[
+                TOOL_NAMES["CREATE_COLLECTION_WITH_META"]
+            ].model_json_schema(),  # Schema now expects a string
+        ),
+        # --- End Re-enable --- #
         types.Tool(
             name=TOOL_NAMES["LIST_COLLECTIONS"],
             description="List all collections with optional filtering and pagination.",
@@ -332,21 +381,6 @@ async def list_tools() -> List[types.Tool]:
             name=TOOL_NAMES["GET_COLLECTION"],
             description="Get information about a specific collection.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["GET_COLLECTION"]].model_json_schema(),
-        ),
-        types.Tool(
-            name=TOOL_NAMES["SET_COLLECTION_DESC"],
-            description="Sets or updates the description of a collection. Note: Due to ChromaDB limitations, this tool will likely fail on existing collections. Set description during creation via metadata instead.",
-            inputSchema=INPUT_MODELS[TOOL_NAMES["SET_COLLECTION_DESC"]].model_json_schema(),
-        ),
-        types.Tool(
-            name=TOOL_NAMES["SET_COLLECTION_SETTINGS"],
-            description="Sets or updates the settings (e.g., HNSW parameters) of a collection. Warning: This replaces existing settings. This will likely fail on existing collections due to immutable settings. Define settings during creation via metadata.",
-            inputSchema=INPUT_MODELS[TOOL_NAMES["SET_COLLECTION_SETTINGS"]].model_json_schema(),
-        ),
-        types.Tool(
-            name=TOOL_NAMES["UPDATE_COLLECTION_META"],
-            description="Updates or adds custom key-value pairs to a collection's metadata (merge). Warning: This REPLACES the entire existing custom metadata block. This will likely fail on existing collections due to immutable settings. Set metadata during creation.",
-            inputSchema=INPUT_MODELS[TOOL_NAMES["UPDATE_COLLECTION_META"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["RENAME_COLLECTION"],
@@ -366,28 +400,74 @@ async def list_tools() -> List[types.Tool]:
         # Document Tools
         types.Tool(
             name=TOOL_NAMES["ADD_DOCS"],
-            description="Add documents to a ChromaDB collection.",
+            description="Add documents to a collection (auto-generates IDs, no metadata).",
             inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS"]].model_json_schema(),
         ),
         types.Tool(
+            name=TOOL_NAMES["ADD_DOCS_IDS"],
+            description="Add documents with specified IDs to a collection (no metadata).",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS_IDS"]].model_json_schema(),
+        ),
+        types.Tool(
+            name=TOOL_NAMES["ADD_DOCS_META"],
+            description="Add documents with specified metadata to a collection (auto-generates IDs).",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS_META"]].model_json_schema(),
+        ),
+        types.Tool(
+            name=TOOL_NAMES["ADD_DOCS_IDS_META"],
+            description="Add documents with specified IDs and metadata to a collection.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS_IDS_META"]].model_json_schema(),
+        ),
+        types.Tool(
             name=TOOL_NAMES["QUERY_DOCS"],
-            description="Query documents in a ChromaDB collection using semantic search.",
+            description="Query documents using semantic search (no filters).",
             inputSchema=INPUT_MODELS[TOOL_NAMES["QUERY_DOCS"]].model_json_schema(),
         ),
         types.Tool(
-            name=TOOL_NAMES["GET_DOCS"],
-            description="Get documents from a ChromaDB collection by ID or filter.",
-            inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS"]].model_json_schema(),
+            name=TOOL_NAMES["QUERY_DOCS_WHERE"],
+            description="Query documents using semantic search with a metadata filter.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["QUERY_DOCS_WHERE"]].model_json_schema(),
         ),
         types.Tool(
-            name=TOOL_NAMES["UPDATE_DOCS"],
-            description="Update existing documents in a ChromaDB collection.",
-            inputSchema=INPUT_MODELS[TOOL_NAMES["UPDATE_DOCS"]].model_json_schema(),
+            name=TOOL_NAMES["QUERY_DOCS_DOC"],
+            description="Query documents using semantic search with a document content filter.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["QUERY_DOCS_DOC"]].model_json_schema(),
+        ),
+        types.Tool(
+            name=TOOL_NAMES["GET_DOCS_IDS"],
+            description="Get documents from a collection by specific IDs.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_IDS"]].model_json_schema(),
+        ),
+        types.Tool(
+            name=TOOL_NAMES["GET_DOCS_WHERE"],
+            description="Get documents from a collection using a metadata filter.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_WHERE"]].model_json_schema(),
+        ),
+        types.Tool(
+            name=TOOL_NAMES["GET_DOCS_DOC"],
+            description="Get documents from a collection using a document content filter.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_DOC"]].model_json_schema(),
+        ),
+        types.Tool(
+            name=TOOL_NAMES["GET_DOCS_ALL"],
+            description="Get all documents from a collection (optional limit/offset).",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_ALL"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["DELETE_DOCS"],
-            description="Delete documents from a ChromaDB collection by ID or filter.",
+            description="Delete documents from a collection by specific IDs.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["DELETE_DOCS"]].model_json_schema(),
+        ),
+        # Update Document Variants
+        types.Tool(
+            name=TOOL_NAMES["UPDATE_DOC_CONTENT"],
+            description="Update the content of existing documents by ID.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["UPDATE_DOC_CONTENT"]].model_json_schema(),
+        ),
+        types.Tool(
+            name=TOOL_NAMES["UPDATE_DOC_META"],
+            description="Update the metadata of existing documents by ID.",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["UPDATE_DOC_META"]].model_json_schema(),
         ),
         # Thinking Tools
         types.Tool(
@@ -449,7 +529,7 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
             version = importlib.metadata.version("chroma-mcp-server")
             result_text = json.dumps({"package": "chroma-mcp-server", "version": version})
             content_list = [types.TextContent(type="text", text=result_text)]
-            logger.debug(f"Returning result for {name}: {content_list}") # Log before return
+            logger.debug(f"Returning result for {name}: {content_list}")  # Log before return
             return content_list
         except importlib.metadata.PackageNotFoundError as e:
             logger.error(f"Error getting server version: {str(e)}", exc_info=True)
@@ -458,7 +538,9 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
         except Exception as e:
             logger.error(f"Error getting server version: {str(e)}", exc_info=True)
             # Raise exception for Server to handle
-            raise McpError(ErrorData(code=INTERNAL_ERROR, message=f"Tool Error: Could not get server version. Details: {str(e)}"))
+            raise McpError(
+                ErrorData(code=INTERNAL_ERROR, message=f"Tool Error: Could not get server version. Details: {str(e)}")
+            )
 
     # --- Get Pydantic Model and Implementation Function --- >
     InputModel = INPUT_MODELS.get(name)
@@ -487,7 +569,7 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
 
     # Add debug log before returning
     logger.debug("Debug log for call_tool result.")
-    logger.debug(f"Returning call_tool result for {name}: {content_list}") # Log before return
+    logger.debug(f"Returning call_tool result for {name}: {content_list}")  # Log before return
     logger.debug("Finished debug log for call_tool result.")
     return content_list
 
@@ -515,9 +597,7 @@ def main() -> None:
                 version = importlib.metadata.version("chroma-mcp-server")
             except importlib.metadata.PackageNotFoundError:
                 version = "unknown"
-            logger.info(
-                f"Chroma MCP server v{version} started. Using stdio transport."
-            )
+            logger.info(f"Chroma MCP server v{version} started. Using stdio transport.")
 
         # Start server with stdio transport using the IMPORTED shared 'server' instance
         # The run method now needs the read/write streams and options

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -360,141 +360,136 @@ async def list_tools() -> List[types.Tool]:
         # Collection Tools
         types.Tool(
             name=TOOL_NAMES["CREATE_COLLECTION"],
-            description="Create a new ChromaDB collection using server default settings.",
+            description="Create a new ChromaDB collection using server default settings. Requires: `collection_name`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["CREATE_COLLECTION"]].model_json_schema(),
         ),
-        # --- Re-enable the metadata tool --- #
         types.Tool(
             name=TOOL_NAMES["CREATE_COLLECTION_WITH_META"],
-            description="Create a new ChromaDB collection with specific metadata/settings provided (as JSON string).",
-            inputSchema=INPUT_MODELS[
-                TOOL_NAMES["CREATE_COLLECTION_WITH_META"]
-            ].model_json_schema(),  # Schema now expects a string
+            description="Create a new ChromaDB collection with specific metadata/settings provided. Requires: `collection_name`, `metadata` (JSON string).",
+            inputSchema=INPUT_MODELS[TOOL_NAMES["CREATE_COLLECTION_WITH_META"]].model_json_schema(),
         ),
-        # --- End Re-enable --- #
         types.Tool(
             name=TOOL_NAMES["LIST_COLLECTIONS"],
-            description="List all collections with optional filtering and pagination.",
+            description="List all collections. Optional: `limit`, `offset`, `name_contains`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["LIST_COLLECTIONS"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["GET_COLLECTION"],
-            description="Get information about a specific collection.",
+            description="Get information about a specific collection. Requires: `collection_name`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["GET_COLLECTION"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["RENAME_COLLECTION"],
-            description="Renames an existing collection.",
+            description="Renames an existing collection. Requires: `collection_name`, `new_name`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["RENAME_COLLECTION"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["DELETE_COLLECTION"],
-            description="Delete a collection.",
+            description="Delete a collection. Requires: `collection_name`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["DELETE_COLLECTION"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["PEEK_COLLECTION"],
-            description="Get a sample of documents from a collection.",
+            description="Get a sample of documents from a collection. Requires: `collection_name`. Optional: `limit`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["PEEK_COLLECTION"]].model_json_schema(),
         ),
         # Document Tools
         types.Tool(
             name=TOOL_NAMES["ADD_DOCS"],
-            description="Add documents to a collection (auto-generates IDs, no metadata).",
+            description="Add a document (auto-generates ID, no metadata). Requires: `collection_name`, `document`. Optional: `increment_index`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["ADD_DOCS_IDS"],
-            description="Add documents with specified IDs to a collection (no metadata).",
+            description="Add a document with a specified ID (no metadata). Requires: `collection_name`, `document`, `id`. Optional: `increment_index`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS_IDS"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["ADD_DOCS_META"],
-            description="Add documents with specified metadata to a collection (auto-generates IDs).",
+            description="Add a document with specified metadata (auto-generates ID). Requires: `collection_name`, `document`, `metadata` (JSON string). Optional: `increment_index`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS_META"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["ADD_DOCS_IDS_META"],
-            description="Add documents with specified IDs and metadata to a collection.",
+            description="Add a document with specified ID and metadata. Requires: `collection_name`, `document`, `id`, `metadata` (JSON string). Optional: `increment_index`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["ADD_DOCS_IDS_META"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["QUERY_DOCS"],
-            description="Query documents using semantic search (no filters).",
+            description="Query documents using semantic search (no filters). Requires: `collection_name`, `query_texts`. Optional: `n_results`, `include`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["QUERY_DOCS"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["QUERY_DOCS_WHERE"],
-            description="Query documents using semantic search with a metadata filter.",
+            description="Query documents using semantic search with a metadata filter. Requires: `collection_name`, `query_texts`, `where`. Optional: `n_results`, `include`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["QUERY_DOCS_WHERE"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["QUERY_DOCS_DOC"],
-            description="Query documents using semantic search with a document content filter.",
+            description="Query documents using semantic search with a document content filter. Requires: `collection_name`, `query_texts`, `where_document`. Optional: `n_results`, `include`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["QUERY_DOCS_DOC"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["GET_DOCS_IDS"],
-            description="Get documents from a collection by specific IDs.",
+            description="Get documents from a collection by specific IDs. Requires: `collection_name`, `ids`. Optional: `include`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_IDS"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["GET_DOCS_WHERE"],
-            description="Get documents from a collection using a metadata filter.",
+            description="Get documents from a collection using a metadata filter. Requires: `collection_name`, `where`. Optional: `limit`, `offset`, `include`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_WHERE"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["GET_DOCS_DOC"],
-            description="Get documents from a collection using a document content filter.",
+            description="Get documents from a collection using a document content filter. Requires: `collection_name`, `where_document`. Optional: `limit`, `offset`, `include`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_DOC"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["GET_DOCS_ALL"],
-            description="Get all documents from a collection (optional limit/offset).",
+            description="Get all documents from a collection. Requires: `collection_name`. Optional: `limit`, `offset`, `include`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["GET_DOCS_ALL"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["DELETE_DOCS"],
-            description="Delete documents from a collection by specific IDs.",
+            description="Delete a document from a collection by its specific ID. Requires: `collection_name`, `id`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["DELETE_DOCS"]].model_json_schema(),
         ),
         # Update Document Variants
         types.Tool(
             name=TOOL_NAMES["UPDATE_DOC_CONTENT"],
-            description="Update the content of existing documents by ID.",
+            description="Update the content of an existing document by ID. Requires: `collection_name`, `id`, `document`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["UPDATE_DOC_CONTENT"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["UPDATE_DOC_META"],
-            description="Update the metadata of existing documents by ID.",
+            description="Update the metadata of an existing document by ID. Requires: `collection_name`, `id`, `metadata` (dict).",
             inputSchema=INPUT_MODELS[TOOL_NAMES["UPDATE_DOC_META"]].model_json_schema(),
         ),
         # Thinking Tools
         types.Tool(
             name=TOOL_NAMES["SEQ_THINKING"],
-            description="Records a single thought as part of a sequential thinking process or workflow.",
+            description="Records a single thought. Requires: `thought`, `thought_number`, `total_thoughts`. Optional: `session_id`, `branch_id`, `branch_from_thought`, `next_thought_needed`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["SEQ_THINKING"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["FIND_THOUGHTS"],
-            description="Finds thoughts across one or all sessions that are semantically similar to a given query.",
+            description="Finds thoughts semantically similar to a query. Requires: `query`. Optional: `session_id`, `n_results`, `threshold`, `include_branches`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["FIND_THOUGHTS"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["GET_SUMMARY"],
-            description="Retrieves all thoughts recorded within a specific thinking session, ordered sequentially.",
+            description="Retrieves all thoughts recorded within a specific thinking session. Requires: `session_id`. Optional: `include_branches`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["GET_SUMMARY"]].model_json_schema(),
         ),
         types.Tool(
             name=TOOL_NAMES["FIND_SESSIONS"],
-            description="Finds thinking sessions whose overall content is semantically similar to a given query.",
+            description="Finds thinking sessions similar to a query. Requires: `query`. Optional: `n_results`, `threshold`.",
             inputSchema=INPUT_MODELS[TOOL_NAMES["FIND_SESSIONS"]].model_json_schema(),
         ),
-        # Utility Tool (Corrected Input Schema)
+        # Utility Tool
         types.Tool(
             name=TOOL_NAMES["GET_VERSION"],
-            description="Return the installed version of the chroma-mcp-server package.",
-            # Use a valid schema for an object with no properties
+            description="Return the installed version of the chroma-mcp-server package. Takes no parameters.",
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -534,13 +529,15 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
         except importlib.metadata.PackageNotFoundError as e:
             logger.error(f"Error getting server version: {str(e)}", exc_info=True)
             # Raise exception for Server to handle
-            raise McpError(ErrorData(code=INTERNAL_ERROR, message="Tool Error: chroma-mcp-server package not found."))
+            error_data = ErrorData(code=INTERNAL_ERROR, message="Tool Error: chroma-mcp-server package not found.")
+            raise McpError(error_data)
         except Exception as e:
             logger.error(f"Error getting server version: {str(e)}", exc_info=True)
             # Raise exception for Server to handle
-            raise McpError(
-                ErrorData(code=INTERNAL_ERROR, message=f"Tool Error: Could not get server version. Details: {str(e)}")
+            error_data = ErrorData(
+                code=INTERNAL_ERROR, message=f"Tool Error: Could not get server version. Details: {str(e)}"
             )
+            raise McpError(error_data)
 
     # --- Get Pydantic Model and Implementation Function --- >
     InputModel = INPUT_MODELS.get(name)
@@ -548,8 +545,9 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
 
     if not InputModel or not impl_function:
         logger.error(f"Unknown tool name received: {name}")
-        # Raise exception for Server to handle
-        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Tool Error: Unknown tool name '{name}'"))
+        # Raise exception for Server to handle, wrapping ErrorData
+        error_data = ErrorData(code=INVALID_PARAMS, message=f"Tool Error: Unknown tool name '{name}'")
+        raise McpError(error_data)
 
     # --- Pydantic Validation --- >
     try:
@@ -558,7 +556,9 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
         logger.debug(f"Validation successful for {name}")
     except ValidationError as e:
         logger.warning(f"Input validation failed for {name}: {e}")
-        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Input Error: {str(e)}"))
+        # Wrap Pydantic error message in McpError with ErrorData
+        error_data = ErrorData(code=INVALID_PARAMS, message=f"Input Error: {str(e)}")
+        raise McpError(error_data)
 
     # --- Call Core Logic --- >
     logger.debug(f"Calling implementation function for {name}")
@@ -616,13 +616,18 @@ def main() -> None:
         if logger:
             logger.error(f"MCP Error: {str(e)}")
         # Re-raise McpError to potentially be caught by CLI
-        raise
+        # Ensure ErrorData is propagated if available, otherwise use the message
+        err_data = (
+            e.args[0] if e.args and isinstance(e.args[0], ErrorData) else ErrorData(code=INTERNAL_ERROR, message=str(e))
+        )
+        raise McpError(err_data)
     except Exception as e:
         error_msg = f"Critical error running MCP server: {str(e)}"
         if logger:
             logger.error(error_msg)
         # Convert unexpected errors to McpError for consistent exit
-        raise McpError(ErrorData(code=INTERNAL_ERROR, message=error_msg))
+        err_data = ErrorData(code=INTERNAL_ERROR, message=error_msg)
+        raise McpError(err_data)
 
 
 if __name__ == "__main__":

--- a/src/chroma_mcp/utils/__init__.py
+++ b/src/chroma_mcp/utils/__init__.py
@@ -57,6 +57,39 @@ def get_server_config() -> ChromaClientConfig:
     return _global_client_config
 
 
+# --- JSON Encoder for NumPy types ---
+import json
+import numpy as np
+
+
+class NumpyEncoder(json.JSONEncoder):
+    """Custom encoder for numpy data types"""
+
+    def default(self, obj):
+        if isinstance(
+            obj,
+            (
+                np.int_,
+                np.intc,
+                np.intp,
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+            ),
+        ):
+            return int(obj)
+        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+            return float(obj)
+        elif isinstance(obj, (np.ndarray,)):
+            return obj.tolist()
+        return super(NumpyEncoder, self).default(obj)
+
+
 # --- Original Utils Exports --- #
 from .client import get_chroma_client, get_embedding_function
 from .errors import ValidationError, EmbeddingError, ClientError, ConfigurationError
@@ -73,4 +106,6 @@ __all__ = [
     "EmbeddingError",
     "ClientError",
     "ConfigurationError",
+    # Helpers
+    "NumpyEncoder",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,13 @@ from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, INTERNAL_ERROR, INVALID_PARAMS
 
 from src.chroma_mcp.types import ChromaClientConfig, ThoughtMetadata
-from src.chroma_mcp.utils import get_chroma_client, get_embedding_function, ValidationError, set_main_logger, set_server_config
+from src.chroma_mcp.utils import (
+    get_chroma_client,
+    get_embedding_function,
+    ValidationError,
+    set_main_logger,
+    set_server_config,
+)
 
 from unittest.mock import MagicMock, patch
 from dotenv import load_dotenv
@@ -40,21 +46,19 @@ from src.chroma_mcp.types import (
     ThoughtMetadata,
     DocumentMetadata,  # Ensure DocumentMetadata is imported
 )
-from src.chroma_mcp.tools.collection_tools import (
-    _create_collection_impl,
-    _list_collections_impl,
-    _get_collection_impl,
-    _set_collection_description_impl,
-    _set_collection_settings_impl,
-    _update_collection_metadata_impl,
-    _rename_collection_impl,
-    _delete_collection_impl,
-    _peek_collection_impl,
-)
-from src.chroma_mcp.tools.thinking_tools import (
-    _sequential_thinking_impl,
-    _find_similar_thoughts_impl,
-)
+
+# from src.chroma_mcp.tools.collection_tools import (
+#     _create_collection_impl,
+#     _list_collections_impl,
+#     _get_collection_impl,
+#     _rename_collection_impl,
+#     _delete_collection_impl,
+#     _peek_collection_impl,
+# )
+# from src.chroma_mcp.tools.thinking_tools import (
+#     _sequential_thinking_impl,
+#     _find_similar_thoughts_impl,
+# )
 
 # --- Start: Logger Configuration for Tests ---
 TEST_LOG_DIR = "logs"
@@ -473,6 +477,7 @@ class MockMCP:
 def patched_mcp():
     """Return a mock MCP instance with all required methods."""
     return MockMCP()
+
 
 # Add this fixture to automatically shut down logging after tests
 @pytest.fixture(autouse=True)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -71,12 +71,13 @@ def mock_get_logger():
 
 # --- Test server.main function --- #
 
+
 # Patch only the components directly used by server.main
-@patch("src.chroma_mcp.server.stdio.stdio_server") # Patch the context manager
-@patch("src.chroma_mcp.server.server.run") # Patch the server.run call
+@patch("src.chroma_mcp.server.stdio.stdio_server")  # Patch the context manager
+@patch("src.chroma_mcp.server.server.run")  # Patch the server.run call
 def test_main_calls_mcp_run(
-    mock_server_run, # Capture patched server.run
-    mock_stdio_cm, # Capture patched context manager
+    mock_server_run,  # Capture patched server.run
+    mock_stdio_cm,  # Capture patched context manager
 ):
     # Mock the context manager to return mock streams
     mock_stdio_cm.return_value.__aenter__.return_value = (MagicMock(), MagicMock())
@@ -84,7 +85,7 @@ def test_main_calls_mcp_run(
     mock_server_run.return_value = None
 
     # --- Act ---
-    main() # Call the real server.main
+    main()  # Call the real server.main
 
     # --- Assert ---
     # stdio_server context manager should be entered
@@ -94,11 +95,11 @@ def test_main_calls_mcp_run(
 
 
 # Patch only the components directly used by server.main
-@patch("src.chroma_mcp.server.stdio.stdio_server") # Patch the context manager
-@patch("src.chroma_mcp.server.server.run") # Patch the server.run call
+@patch("src.chroma_mcp.server.stdio.stdio_server")  # Patch the context manager
+@patch("src.chroma_mcp.server.server.run")  # Patch the server.run call
 def test_main_catches_mcp_run_mcp_error(
-    mock_server_run, # Capture patched server.run
-    mock_stdio_cm, # Capture patched context manager
+    mock_server_run,  # Capture patched server.run
+    mock_stdio_cm,  # Capture patched context manager
     caplog,
 ):
     # Mock the context manager
@@ -119,11 +120,11 @@ def test_main_catches_mcp_run_mcp_error(
 
 
 # Patch only the components directly used by server.main
-@patch("src.chroma_mcp.server.stdio.stdio_server") # Patch the context manager
-@patch("src.chroma_mcp.server.server.run") # Patch the server.run call
+@patch("src.chroma_mcp.server.stdio.stdio_server")  # Patch the context manager
+@patch("src.chroma_mcp.server.server.run")  # Patch the server.run call
 def test_main_catches_mcp_run_unexpected_error(
-    mock_server_run, # Capture patched server.run
-    mock_stdio_cm, # Capture patched context manager
+    mock_server_run,  # Capture patched server.run
+    mock_stdio_cm,  # Capture patched context manager
     caplog,
 ):
     # Mock the context manager

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,14 +12,24 @@ import pytest
 import trio
 import sys
 import logging  # Import logging
+import json
 
 # Import McpError and INTERNAL_ERROR from exceptions
+from mcp import types  # Add this import
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, INTERNAL_ERROR, INVALID_PARAMS
 
 # Local application imports
 # Import main and config_server from server
-from src.chroma_mcp.server import main, config_server
+# Change alias for main to avoid potential conflicts
+from src.chroma_mcp.server import (
+    config_server,
+    call_tool,
+    TOOL_NAMES,
+    INPUT_MODELS,
+    IMPL_FUNCTIONS,
+    main as run_server_main_func,
+)
 
 # Keep ValidationError import
 from chroma_mcp.utils.errors import ValidationError
@@ -32,6 +42,12 @@ from chroma_mcp.utils import get_logger
 
 # Import server instance
 from chroma_mcp.app import server
+
+# Import types needed for tests
+from src.chroma_mcp.types import ChromaClientConfig
+
+# Import utils used by server
+from src.chroma_mcp.utils import set_main_logger, set_server_config, BASE_LOGGER_NAME
 
 
 # Mock dependencies globally
@@ -85,7 +101,7 @@ def test_main_calls_mcp_run(
     mock_server_run.return_value = None
 
     # --- Act ---
-    main()  # Call the real server.main
+    run_server_main_func()  # Call the real server.main
 
     # --- Assert ---
     # stdio_server context manager should be entered
@@ -111,7 +127,7 @@ def test_main_catches_mcp_run_mcp_error(
     # --- Act & Assert ---
     # Expect server.main() to catch the McpError and re-raise it
     with pytest.raises(McpError) as exc_info:
-        main()
+        run_server_main_func()
     assert error_message in str(exc_info.value)
 
     # Check logs (server.main logs the error before re-raising)
@@ -136,7 +152,7 @@ def test_main_catches_mcp_run_unexpected_error(
     # --- Act & Assert ---
     # Expect server.main() to catch the error, log, and raise McpError
     with pytest.raises(McpError) as exc_info:
-        main()
+        run_server_main_func()
 
     # Check the raised McpError message
     assert f"Critical error running MCP server: {error_message}" in str(exc_info.value)
@@ -144,3 +160,263 @@ def test_main_catches_mcp_run_unexpected_error(
     # Check logs (server.main logs the critical error)
     assert "Critical error running MCP server:" in caplog.text
     assert error_message in caplog.text
+
+
+# --- Helper: Create Dummy Args --- #
+def create_dummy_args(**kwargs):
+    """Creates a dummy argparse.Namespace with defaults."""
+    defaults = {
+        "dotenv_path": None,
+        "log_dir": None,
+        "log_level": "INFO",
+        "client_type": "ephemeral",
+        "data_dir": None,
+        "host": None,
+        "port": None,
+        "ssl": True,
+        "tenant": None,
+        "database": None,
+        "api_key": None,
+        "cpu_execution_provider": "auto",
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# --- Tests for config_server --- #
+
+
+@patch("os.path.exists", return_value=False)
+@patch("src.chroma_mcp.server.set_main_logger")
+@patch("src.chroma_mcp.server.set_server_config")
+@patch("logging.getLogger")  # Mock getLogger to control logger behavior
+@patch("os.getenv")  # Mock os.getenv
+def test_config_server_basic(mock_getenv, mock_get_logger, mock_set_config, mock_set_logger, mock_exists):
+    """Test basic server configuration."""
+    mock_logger = MagicMock(spec=logging.Logger)
+    mock_get_logger.return_value = mock_logger
+    # Configure getenv mock to return the desired level for LOG_LEVEL
+    mock_getenv.side_effect = lambda key, default=None: "DEBUG" if key == "LOG_LEVEL" else default
+    args = create_dummy_args(log_level="DEBUG")  # Args value is actually ignored by config_server for log_level
+
+    # Explicitly reset level on the mock before test
+    mock_logger.level = logging.NOTSET  # Or another value != DEBUG/INFO
+
+    config_server(args)
+
+    mock_set_logger.assert_called_once_with(mock_logger)
+    mock_logger.setLevel.assert_called_once_with(logging.DEBUG)
+    mock_set_config.assert_called_once()
+    # Check the created config object
+    call_args, _ = mock_set_config.call_args
+    config_obj = call_args[0]
+    assert isinstance(config_obj, ChromaClientConfig)
+    assert config_obj.client_type == "ephemeral"
+    assert config_obj.use_cpu_provider is None  # auto
+    mock_logger.info.assert_any_call("Server configured (CPU provider: auto-detected)")
+
+
+@patch("os.makedirs")
+@patch("logging.handlers.RotatingFileHandler")
+@patch("src.chroma_mcp.server.set_main_logger")
+@patch("src.chroma_mcp.server.set_server_config")
+@patch("logging.getLogger")
+def test_config_server_with_log_file(
+    mock_get_logger, mock_set_config, mock_set_logger, mock_file_handler, mock_makedirs
+):
+    """Test server configuration with log file creation."""
+    mock_logger = MagicMock(spec=logging.Logger)
+    # Simulate logger not having handlers initially
+    mock_logger.hasHandlers.return_value = False
+    mock_get_logger.return_value = mock_logger
+    log_dir = "/fake/log/dir"
+    args = create_dummy_args(log_dir=log_dir)
+
+    config_server(args)
+
+    mock_makedirs.assert_called_once_with(log_dir, exist_ok=True)
+    mock_file_handler.assert_called_once_with(
+        f"{log_dir}/chroma_mcp_server.log", maxBytes=10 * 1024 * 1024, backupCount=5
+    )
+    # Check if file handler was added
+    mock_logger.addHandler.assert_any_call(mock_file_handler.return_value)
+    mock_logger.info.assert_any_call(f"Logs will be saved to: {log_dir}")
+
+
+@patch("src.chroma_mcp.server.set_server_config")
+@patch("logging.getLogger")
+def test_config_server_cpu_provider_false(mock_get_logger, mock_set_config):
+    """Test server config forces CPU provider off."""
+    mock_logger = MagicMock(spec=logging.Logger)
+    mock_get_logger.return_value = mock_logger
+    args = create_dummy_args(cpu_execution_provider="false")
+
+    config_server(args)
+
+    mock_set_config.assert_called_once()
+    call_args, _ = mock_set_config.call_args
+    config_obj = call_args[0]
+    assert config_obj.use_cpu_provider is False
+    mock_logger.info.assert_any_call("Server configured (CPU provider: disabled)")
+
+
+@patch("src.chroma_mcp.server.load_dotenv", side_effect=Exception("dotenv fail"))
+@patch("logging.getLogger")
+def test_config_server_dotenv_error(mock_get_logger, mock_load_dotenv, capsys):
+    """Test exception during dotenv load is caught and raised as McpError."""
+    # NOTE: Removed mock_logger as it won't be configured when error happens early
+    # mock_logger = MagicMock(spec=logging.Logger)
+    # mock_get_logger.return_value = mock_logger
+    args = create_dummy_args(dotenv_path="/path/to/.env")  # Assume exists for this test
+
+    # Need to mock os.path.exists if dotenv_path is set
+    with patch("os.path.exists", return_value=True):
+        with pytest.raises(McpError) as excinfo:
+            config_server(args)
+
+    assert "Failed to configure server: dotenv fail" in str(excinfo.value)
+    # Check stderr for the critical error message
+    captured = capsys.readouterr()
+    assert "CRITICAL CONFIG ERROR: Failed to configure server: dotenv fail" in captured.err
+    # mock_logger.critical.assert_called_once_with("Failed to configure server: dotenv fail") # Logger not configured yet
+
+
+@patch("src.chroma_mcp.server.set_main_logger", side_effect=Exception("logger fail"))
+@patch("logging.getLogger")
+def test_config_server_logger_error(mock_get_logger, mock_set_main_logger):
+    """Test exception during logger setup is caught and raised."""
+    # Test case where logger setup itself fails
+    args = create_dummy_args()
+    with pytest.raises(McpError) as excinfo:
+        config_server(args)
+    assert "Failed to configure server: logger fail" in str(excinfo.value)
+    # print might be called if logger setup fails early
+
+
+# --- Tests for call_tool --- #
+
+
+@pytest.mark.asyncio
+@patch("importlib.metadata.version", return_value="1.2.3")
+async def test_call_tool_get_version_success(mock_version):
+    """Test successful call to get_version tool."""
+    tool_name = TOOL_NAMES["GET_VERSION"]
+    arguments = {}
+
+    result = await call_tool(tool_name, arguments)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], types.TextContent)
+    assert result[0].type == "text"
+    expected_data = {"package": "chroma-mcp-server", "version": "1.2.3"}
+    assert json.loads(result[0].text) == expected_data
+    mock_version.assert_called_once_with("chroma-mcp-server")
+
+
+@pytest.mark.asyncio
+@patch("importlib.metadata.version", side_effect=importlib.metadata.PackageNotFoundError("not found"))
+async def test_call_tool_get_version_package_not_found(mock_version):
+    """Test get_version tool when package is not found."""
+    tool_name = TOOL_NAMES["GET_VERSION"]
+    arguments = {}
+
+    with pytest.raises(McpError) as excinfo:
+        await call_tool(tool_name, arguments)
+
+    # Check the string representation of the exception
+    assert "Tool Error: chroma-mcp-server package not found." in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_unknown_tool():
+    """Test calling an unknown tool name."""
+    tool_name = "non_existent_tool"
+    arguments = {"arg1": "val1"}
+
+    with pytest.raises(McpError) as excinfo:
+        await call_tool(tool_name, arguments)
+
+    # Check the string representation of the exception
+    assert f"Tool Error: Unknown tool name '{tool_name}'" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_validation_error():
+    """Test call_tool raising McpError on Pydantic validation failure."""
+    # Use a tool that has required arguments, like create_collection
+    tool_name = TOOL_NAMES["CREATE_COLLECTION"]
+    arguments = {}  # Missing required 'collection_name'
+
+    with pytest.raises(McpError) as excinfo:
+        await call_tool(tool_name, arguments)
+
+    # Check the string representation of the exception
+    assert "Input Error:" in str(excinfo.value)
+    assert "Field required" in str(excinfo.value)  # Pydantic detail should be included
+
+
+# --- Tests for server_main --- #
+
+
+@patch("src.chroma_mcp.server.get_logger")
+@patch("importlib.metadata.version", return_value="1.2.3")
+@patch("src.chroma_mcp.server.stdio.stdio_server")
+@patch("src.chroma_mcp.server.server.run")  # Mock the server run loop
+@patch("asyncio.run")  # Mock asyncio.run
+def test_server_main_success(mock_async_run, mock_mcp_run, mock_stdio, mock_version, mock_get_logger):
+    """Test successful run of server_main."""
+    mock_logger = MagicMock()
+    mock_get_logger.return_value = mock_logger
+    # Mock the async context manager
+    mock_stdio.return_value.__aenter__.return_value = (MagicMock(), MagicMock())
+
+    run_server_main_func()
+
+    mock_logger.info.assert_any_call("Chroma MCP server v1.2.3 started. Using stdio transport.")
+    mock_async_run.assert_called_once()  # Check that asyncio.run was called
+    # Further checks could involve asserting calls within the nested async def run_server
+    # For simplicity, we check the top-level asyncio.run call
+
+
+@patch("src.chroma_mcp.server.get_logger")
+@patch("src.chroma_mcp.server.server.run", side_effect=McpError(ErrorData(code=INTERNAL_ERROR, message="Run failed")))
+@patch("asyncio.run")
+def test_server_main_mcp_error(mock_async_run, mock_mcp_run, mock_get_logger):
+    """Test server_main catches and logs McpError."""
+    mock_logger = MagicMock()
+    mock_get_logger.return_value = mock_logger
+
+    # Mock asyncio.run to simulate the inner function raising the error AFTER run_server_main_func calls asyncio.run
+    mock_async_run.side_effect = mock_mcp_run.side_effect  # Make asyncio.run raise the error
+
+    # Need to mock stdio_server as well if server.run is called within its context
+    with patch("src.chroma_mcp.server.stdio.stdio_server") as mock_stdio:
+        mock_stdio.return_value.__aenter__.return_value = (MagicMock(), MagicMock())
+        with pytest.raises(McpError) as excinfo:  # server_main should re-raise
+            run_server_main_func()
+
+    # Check the string representation of the exception
+    assert "Run failed" in str(excinfo.value)
+    mock_logger.error.assert_any_call("MCP Error: Run failed")
+
+
+@patch("src.chroma_mcp.server.get_logger")
+@patch("src.chroma_mcp.server.server.run", side_effect=Exception("Unexpected crash"))
+@patch("asyncio.run")
+def test_server_main_unexpected_exception(mock_async_run, mock_mcp_run, mock_get_logger):
+    """Test server_main catches and wraps unexpected exceptions."""
+    mock_logger = MagicMock()
+    mock_get_logger.return_value = mock_logger
+
+    # Mock asyncio.run to simulate the inner function raising the error
+    mock_async_run.side_effect = mock_mcp_run.side_effect  # Make asyncio.run raise the error
+
+    with patch("src.chroma_mcp.server.stdio.stdio_server") as mock_stdio:
+        mock_stdio.return_value.__aenter__.return_value = (MagicMock(), MagicMock())
+        with pytest.raises(McpError) as excinfo:
+            run_server_main_func()
+
+    # Check the string representation of the exception
+    assert "Critical error running MCP server: Unexpected crash" in str(excinfo.value)
+    mock_logger.error.assert_called_once_with("Critical error running MCP server: Unexpected crash")

--- a/tests/tools/test_document_tools.py
+++ b/tests/tools/test_document_tools.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from typing import Dict, Any, List, Optional
 from unittest.mock import patch, MagicMock, ANY, call, AsyncMock
-from contextlib import contextmanager # Import contextmanager
+from contextlib import contextmanager  # Import contextmanager
 
 # Import CallToolResult and TextContent for helpers
 from mcp import types
@@ -20,35 +20,64 @@ from mcp.shared.exceptions import McpError
 from src.chroma_mcp.utils.errors import ValidationError
 from src.chroma_mcp.tools import document_tools
 
-# Import the implementation functions directly
+# Import the implementation functions directly - Updated for variants
 from src.chroma_mcp.tools.document_tools import (
-    _add_documents_impl,
+    # Add variants (Singular)
+    _add_document_impl,
+    _add_document_with_id_impl,
+    _add_document_with_metadata_impl,
+    _add_document_with_id_and_metadata_impl,
+    # Query variants (Keep multi)
     _query_documents_impl,
-    _get_documents_impl,
-    _update_documents_impl,
-    _delete_documents_impl,
+    _query_documents_with_where_filter_impl,
+    _query_documents_with_document_filter_impl,
+    # Get variants (Keep multi/filter)
+    _get_documents_by_ids_impl,
+    _get_documents_with_where_filter_impl,
+    _get_documents_with_document_filter_impl,
+    _get_all_documents_impl,
+    # Update variants (Singular)
+    _update_document_content_impl,
+    _update_document_metadata_impl,
+    # Delete variants (Singular ID only)
+    _delete_document_by_id_impl,
 )
 
-# Import Pydantic models
+# Import Pydantic models - Updated for variants
 from src.chroma_mcp.tools.document_tools import (
-    AddDocumentsInput,
+    # Add variants (Singular)
+    AddDocumentInput,
+    AddDocumentWithIDInput,
+    AddDocumentWithMetadataInput,
+    AddDocumentWithIDAndMetadataInput,
+    # Query variants (Keep multi/filter)
     QueryDocumentsInput,
-    GetDocumentsInput,
-    UpdateDocumentsInput,
-    DeleteDocumentsInput,
+    QueryDocumentsWithWhereFilterInput,
+    QueryDocumentsWithDocumentFilterInput,
+    # Get variants (Keep multi/filter)
+    GetDocumentsByIdsInput,
+    GetDocumentsWithWhereFilterInput,
+    GetDocumentsWithDocumentFilterInput,
+    GetAllDocumentsInput,
+    # Update variants (Singular)
+    UpdateDocumentContentInput,
+    UpdateDocumentMetadataInput,
+    # Delete variants (Singular ID only)
+    DeleteDocumentByIdInput,
 )
 
 # Import Chroma exceptions used in mocking
-from chromadb.errors import InvalidDimensionException # No longer needed
+from chromadb.errors import InvalidDimensionException  # No longer needed
 
 # Import necessary helpers from utils
-from src.chroma_mcp.utils.config import get_collection_settings # Not used here
+from src.chroma_mcp.utils.config import get_collection_settings  # Not used here
 from src.chroma_mcp.utils import get_logger, get_chroma_client, get_embedding_function, ValidationError
 from src.chroma_mcp.utils.config import validate_collection_name
 
 DEFAULT_SIMILARITY_THRESHOLD = 0.7
 
 # --- Helper Functions (Consider moving to a shared conftest.py) ---
+
 
 def assert_successful_json_result(
     result: List[types.TextContent],
@@ -74,19 +103,22 @@ def assert_successful_json_result(
             # Optionally add value comparison: assert parsed_data[key] == expected_data[key]
     return parsed_data
 
+
 # Define the helper context manager for McpError
 @contextmanager
 def assert_raises_mcp_error(expected_error_substring: Optional[str] = None):
     """Asserts that McpError is raised and optionally checks the error message."""
     with pytest.raises(McpError) as exc_info:
-        yield # Code under test executes here
+        yield  # Code under test executes here
 
     # After the block, check the exception details
-    error_message = str(exc_info.value) # Use the string representation of the exception
+    error_message = str(exc_info.value)  # Use the string representation of the exception
     # print(f"DEBUG: Caught McpError message: {error_message}") # Keep commented out for now
     if expected_error_substring:
-        assert expected_error_substring.lower() in error_message.lower(), \
-               f"Expected substring '{expected_error_substring}' not found in error message '{error_message}'"
+        assert (
+            expected_error_substring.lower() in error_message.lower()
+        ), f"Expected substring '{expected_error_substring}' not found in error message '{error_message}'"
+
 
 # --- End Helper Functions ---
 
@@ -103,19 +135,30 @@ def mock_chroma_client_document():
         # Use AsyncMock for the client and collection methods if they are awaited
         # But the underlying Chroma client is synchronous, so MagicMock is appropriate
         mock_client_instance = MagicMock()
-        mock_collection_instance = MagicMock(name="document_collection") # Name for clarity
+        mock_collection_instance = MagicMock(name="document_collection")  # Name for clarity
 
         # Configure default behaviors for collection methods
-        mock_collection_instance.add.return_value = None # add returns None
-        mock_collection_instance.query.return_value = { # Default empty query result
-             "ids": [], "distances": [], "metadatas": [], "embeddings": [], "documents": [], "uris": [], "data": None
+        mock_collection_instance.add.return_value = None  # add returns None
+        mock_collection_instance.query.return_value = {  # Default empty query result
+            "ids": [],
+            "distances": [],
+            "metadatas": [],
+            "embeddings": [],
+            "documents": [],
+            "uris": [],
+            "data": None,
         }
-        mock_collection_instance.get.return_value = { # Default empty get result
-             "ids": [], "metadatas": [], "embeddings": [], "documents": [], "uris": [], "data": None
+        mock_collection_instance.get.return_value = {  # Default empty get result
+            "ids": [],
+            "metadatas": [],
+            "embeddings": [],
+            "documents": [],
+            "uris": [],
+            "data": None,
         }
-        mock_collection_instance.update.return_value = None # update returns None
-        mock_collection_instance.delete.return_value = [] # delete returns list of deleted IDs
-        mock_collection_instance.count.return_value = 0 # Default count
+        mock_collection_instance.update.return_value = None  # update returns None
+        mock_collection_instance.delete.return_value = []  # delete returns list of deleted IDs
+        mock_collection_instance.count.return_value = 0  # Default count
 
         # Configure client methods
         mock_client_instance.get_collection.return_value = mock_collection_instance
@@ -123,9 +166,9 @@ def mock_chroma_client_document():
         # Configure helper mocks
         mock_get_client.return_value = mock_client_instance
         mock_get_embedding_function.return_value = MagicMock(name="mock_embedding_function")
-        mock_validate_name.return_value = None # Assume valid name by default
+        mock_validate_name.return_value = None  # Assume valid name by default
 
-        yield mock_client_instance, mock_collection_instance, mock_validate_name # Yield validator too
+        yield mock_client_instance, mock_collection_instance, mock_validate_name  # Yield validator too
 
 
 class TestDocumentTools:
@@ -133,407 +176,498 @@ class TestDocumentTools:
 
     # --- _add_documents_impl Tests ---
     @pytest.mark.asyncio
-    async def test_add_documents_success(self, mock_chroma_client_document):
-        """Test successfully adding documents."""
-        mock_client, mock_collection, mock_validate = mock_chroma_client_document # Unpack validator
-        collection_name = "add_coll"
-        docs = ["doc1", "doc2"]
-        ids = ["id_a", "id_b"]
-        metas = [{'k': 'v1'}, {'k': 'v2'}]
-
-        # --- Act ---
-        input_model = AddDocumentsInput(
-            collection_name=collection_name, documents=docs, ids=ids, metadatas=metas, increment_index=False
-        )
-        result = await _add_documents_impl(input_model)
-
-        # --- Assert ---
-        mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        # Check add was called synchronously with correct args
-        mock_collection.add.assert_called_once_with(documents=docs, metadatas=metas, ids=ids)
-
-        # Use helper to check result format and parse JSON
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("status") == "success"
-        assert result_data.get("added_count") == 2
-        assert result_data.get("collection_name") == collection_name
-        assert result_data.get("document_ids") == ids
-        assert result_data.get("ids_generated") is False
-
-    @pytest.mark.asyncio
-    async def test_add_documents_increment_index(self, mock_chroma_client_document):
-        """Test add documents with increment_index=True (logs intent)."""
+    async def test_add_document_success(self, mock_chroma_client_document):
+        """Test successful document addition (auto-ID, no metadata)."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "add_inc_coll"
-        docs = ["doc_inc"]
+        collection_name = "test_add_success"
+        document_to_add = "doc1"  # Singular
 
         # --- Act ---
-        input_model = AddDocumentsInput(collection_name=collection_name, documents=docs, increment_index=True)
-        result = await _add_documents_impl(input_model)
+        input_model = AddDocumentInput(collection_name=collection_name, document=document_to_add)
+        # Mock add to capture generated ID
+        generated_id_capture = None
+
+        def capture_add(*args, **kwargs):
+            nonlocal generated_id_capture
+            generated_id_capture = kwargs.get("ids", [None])[0]
+            return None
+
+        mock_collection.add.side_effect = capture_add
+
+        result = await _add_document_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.add.assert_called_once() # Check add was called
-        # REMOVED: create_index is no longer called directly
-        # mock_collection.create_index.assert_called_once()
-
-        # Assert successful result (basic check is sufficient)
-        assert_successful_json_result(result)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Check add called with list of size 1
+        mock_collection.add.assert_called_once_with(documents=[document_to_add], ids=ANY, metadatas=None)
+        assert generated_id_capture is not None  # Ensure ID was captured
+        assert_successful_json_result(result, {"added_id": generated_id_capture})
 
     @pytest.mark.asyncio
-    async def test_add_documents_collection_not_found(self, mock_chroma_client_document):
-        """Test adding documents when collection not found."""
+    async def test_add_document_increment_index(self, mock_chroma_client_document):
+        """Test document addition respecting increment_index flag."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_add_increment"
+        document_to_add = "doc_inc1"  # Singular
+
+        # --- Act #
+        # Test with increment_index=False (explicitly)
+        input_model_false = AddDocumentInput(
+            collection_name=collection_name, document=document_to_add, increment_index=False
+        )
+        await _add_document_impl(input_model_false)
+
+        # --- Assert #
+        mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.add.assert_called_once_with(documents=[document_to_add], ids=ANY, metadatas=None)
+
+        # Reset mocks for next call
+        mock_validate.reset_mock()
+        mock_client.get_collection.reset_mock()
+        mock_collection.add.reset_mock()
+
+        # --- Act #
+        # Test with increment_index=True (default)
+        input_model_true = AddDocumentInput(collection_name=collection_name, document=document_to_add)
+        await _add_document_impl(input_model_true)
+
+        # --- Assert #
+        mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.add.assert_called_once_with(documents=[document_to_add], ids=ANY, metadatas=None)
+
+    @pytest.mark.asyncio
+    async def test_add_document_collection_not_found(self, mock_chroma_client_document):
+        """Test adding document to a non-existent collection."""
         mock_client, _, mock_validate = mock_chroma_client_document
         collection_name = "add_not_found"
         error_message = f"Collection {collection_name} does not exist."
         mock_client.get_collection.side_effect = ValueError(error_message)
 
         # --- Act & Assert ---
-        input_model = AddDocumentsInput(collection_name=collection_name, documents=["d"])
-        # Expect McpError
-        # assert_error_result(result, f"Tool Error: Collection '{collection_name}' not found.")
-        with assert_raises_mcp_error(f"Tool Error: Collection '{collection_name}' not found."):
-             await _add_documents_impl(input_model)
+        input_model = AddDocumentInput(collection_name=collection_name, document="doc")
+        with assert_raises_mcp_error(f"Collection '{collection_name}' not found."):
+            await _add_document_impl(input_model)
 
-        # Assert mocks
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
 
     @pytest.mark.asyncio
-    async def test_add_documents_chroma_error(self, mock_chroma_client_document):
-        """Test handling errors during the add process."""
+    async def test_add_document_chroma_error(self, mock_chroma_client_document):
+        """Test handling errors during the actual Chroma add call."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
         collection_name = "add_chroma_fail"
-        error_message = "Insertion failed due to dimension mismatch."
-        # Mock get success, add failure
+        error_message = "Chroma add failure"
         mock_client.get_collection.return_value = mock_collection
-        # Use generic Exception for mocking side effect
         mock_collection.add.side_effect = Exception(error_message)
 
         # --- Act & Assert ---
-        input_model = AddDocumentsInput(collection_name=collection_name, documents=["d"])
-        # Expect McpError
-        # assert_error_result(result, f"ChromaDB Error: Failed to add documents. {error_message}")
-        with assert_raises_mcp_error(f"ChromaDB Error: Failed to add documents. {error_message}"):
-            await _add_documents_impl(input_model)
+        input_model = AddDocumentInput(collection_name=collection_name, document="doc")
+        with assert_raises_mcp_error(f"An unexpected error occurred: {error_message}"):
+            await _add_document_impl(input_model)
 
-        # Assert mocks
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.add.assert_called_once()
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.add.assert_called_once()  # Verify add was attempted
 
     @pytest.mark.asyncio
-    async def test_add_documents_generate_ids(self, mock_chroma_client_document):
-        """Test document addition with auto-generated IDs."""
+    async def test_add_document_with_id_success(self, mock_chroma_client_document):
+        """Test successful addition using AddDocumentWithIDInput (ID provided)."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "add_gen_ids"
-        docs = ["docA", "docB"]
-        # Mock collection.count() response for ID generation
-        mock_collection.count.return_value = 3 # Simulate 3 existing docs
-        start_time_ns = time.time_ns() # Use nanoseconds like implementation
+        collection_name = "test_add_with_id"
+        document_to_add = "doc_id1"  # Singular
+        id_to_add = "id1"  # Singular
 
         # --- Act ---
-        # increment_index=True is default
-        input_model = AddDocumentsInput(collection_name=collection_name, documents=docs)
-        result = await _add_documents_impl(input_model)
+        input_model = AddDocumentWithIDInput(collection_name=collection_name, document=document_to_add, id=id_to_add)
+        result = await _add_document_with_id_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        # REMOVED: count is called in the implementation, but asserting it here is brittle
-        # mock_collection.count.assert_called_once() # Assert count WAS called for ID gen
-        mock_collection.add.assert_called_once()
-        call_args = mock_collection.add.call_args
-        assert call_args.kwargs["documents"] == docs
-        assert call_args.kwargs["metadatas"] is None # Ensure None was passed
-        # Check generated IDs format (basic check)
-        generated_ids = call_args.kwargs["ids"]
-        assert len(generated_ids) == 2
-        # Match the nanosecond format: doc_<timestamp_ns>_<index>
-        # Loosen timestamp match slightly due to potential timing difference
-        assert re.match(rf"doc_{start_time_ns // 1_000_000_000}", generated_ids[0]) # Check prefix and seconds part
-        assert generated_ids[0].endswith("_3") # Check index part (3 + 0)
-        assert generated_ids[1].endswith("_4") # Check index part (3 + 1)
-
-        # Use helper to check result format and parse JSON
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("status") == "success"
-        assert result_data.get("added_count") == 2
-        assert result_data.get("ids_generated") is True
-        assert result_data.get("document_ids") == generated_ids # Check returned IDs match
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Assert add called with list of size 1
+        mock_collection.add.assert_called_once_with(documents=[document_to_add], ids=[id_to_add], metadatas=None)
+        # Assert result contains the provided ID
+        assert_successful_json_result(result, {"added_id": id_to_add})
 
     @pytest.mark.asyncio
-    async def test_add_documents_generate_ids_no_increment(self, mock_chroma_client_document):
-        """Test document addition with auto-generated IDs without incrementing index."""
+    async def test_add_document_with_id_no_increment(self, mock_chroma_client_document):
+        """Test addition with ID and increment_index=False."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "add_gen_noinc"
-        docs = ["docX"]
-        # Mock count behavior - it *is* called for ID generation
-        mock_collection.count.return_value = 0 # Simulate empty collection for ID gen
-        start_time_ns = time.time_ns()
+        collection_name = "test_add_with_id_noinc"
+        document_to_add = "doc_id_noinc"  # Singular
+        id_to_add = "id_noinc1"  # Singular
 
         # --- Act ---
-        input_model = AddDocumentsInput(collection_name=collection_name, documents=docs, increment_index=False)
-        result = await _add_documents_impl(input_model)
-
-        # --- Assert ---
-        mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        # REMOVED: count is called in the implementation, but asserting it here is brittle
-        # mock_collection.count.assert_called_once() # Assert count WAS called for ID gen
-        mock_collection.add.assert_called_once()
-        call_args = mock_collection.add.call_args
-        generated_ids = call_args.kwargs["ids"]
-        assert len(generated_ids) == 1
-        # Loosen timestamp match
-        assert re.match(rf"doc_{start_time_ns // 1_000_000_000}", generated_ids[0])
-        # Index starts from 0 because increment_index=False
-        assert generated_ids[0].endswith("_0")
-
-        # Use helper to check result format and parse JSON
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("ids_generated") is True
-        assert result_data.get("document_ids") == generated_ids
-
-    @pytest.mark.asyncio
-    async def test_add_documents_validation_no_docs(self, mock_chroma_client_document):
-        """Test validation success when no documents are provided (should add 0)."""
-        mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_valid"
-        # --- Act ---
-        input_model = AddDocumentsInput(collection_name=collection_name, documents=[])
-        result = await _add_documents_impl(input_model)
-
-        # --- Assert ---
-        mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        # Expect success, adding 0 documents
-        # Implementation calls add with empty lists
-        mock_collection.add.assert_called_once_with(documents=[], ids=[], metadatas=None)
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("status") == "success"
-        assert result_data.get("added_count") == 0
-        assert result_data.get("collection_name") == collection_name
-        assert result_data.get("document_ids") == []
-
-    @pytest.mark.asyncio
-    async def test_add_documents_validation_mismatch_ids(self, mock_chroma_client_document):
-        """Test validation failure with mismatched IDs."""
-        _, _, mock_validate = mock_chroma_client_document
-        collection_name = "test_valid_mismatch_id"
-        input_model = AddDocumentsInput(
-            collection_name=collection_name, documents=["d1", "d2"], ids=["id1"], increment_index=True
+        input_model = AddDocumentWithIDInput(
+            collection_name=collection_name, document=document_to_add, id=id_to_add, increment_index=False
         )
-        # assert_error_result(result, "Validation Error: Number of IDs must match number of documents")
-        with assert_raises_mcp_error("Validation Error: Number of IDs must match number of documents"):
-            await _add_documents_impl(input_model)
-        mock_validate.assert_called_once_with(collection_name) # Validation happens before get_collection
+        result = await _add_document_with_id_impl(input_model)
+
+        # --- Assert ---
+        mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.add.assert_called_once_with(documents=[document_to_add], ids=[id_to_add], metadatas=None)
+        assert_successful_json_result(result, {"added_id": id_to_add})
 
     @pytest.mark.asyncio
-    async def test_add_documents_validation_mismatch_metas(self, mock_chroma_client_document):
-        """Test validation failure with mismatched metadatas."""
-        _, _, mock_validate = mock_chroma_client_document
-        collection_name = "test_valid_mismatch_meta"
-        input_model = AddDocumentsInput(
-            collection_name=collection_name, documents=["d1", "d2"], metadatas=[{"k": "v"}], increment_index=True
-        )
-        # assert_error_result(result, "Validation Error: Number of metadatas must match number of documents")
-        with assert_raises_mcp_error("Validation Error: Number of metadatas must match number of documents"):
-            await _add_documents_impl(input_model)
-        mock_validate.assert_called_once_with(collection_name) # Validation happens before get_collection
+    async def test_add_document_validation_no_doc_or_id(self, mock_chroma_client_document):
+        """Test validation failure when document or ID is empty."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_add_valid_empties"
 
-    # --- _query_documents_impl Tests ---
+        # Test AddDocumentInput with empty document
+        input_model_base = AddDocumentInput(collection_name=collection_name, document="")
+        with assert_raises_mcp_error("Document content cannot be empty."):
+            await _add_document_impl(input_model_base)
+
+        # Test AddDocumentWithIDInput with empty document
+        input_model_id_doc = AddDocumentWithIDInput(collection_name=collection_name, document="", id="some_id")
+        with assert_raises_mcp_error("Document content cannot be empty."):
+            await _add_document_with_id_impl(input_model_id_doc)
+
+        # Test AddDocumentWithIDInput with empty ID
+        input_model_id_id = AddDocumentWithIDInput(collection_name=collection_name, document="some_doc", id="")
+        with assert_raises_mcp_error("Document ID cannot be empty."):
+            await _add_document_with_id_impl(input_model_id_id)
+
+        # Test AddDocumentWithMetadataInput with empty document
+        input_model_meta_doc = AddDocumentWithMetadataInput(collection_name=collection_name, document="", metadata="{}")
+        with assert_raises_mcp_error("Document content cannot be empty."):
+            await _add_document_with_metadata_impl(input_model_meta_doc)
+
+        # Test AddDocumentWithMetadataInput with empty metadata string
+        input_model_meta_meta = AddDocumentWithMetadataInput(
+            collection_name=collection_name, document="doc", metadata=""
+        )
+        with assert_raises_mcp_error("Metadata JSON string cannot be empty."):
+            await _add_document_with_metadata_impl(input_model_meta_meta)
+
+        # Test AddDocumentWithIDAndMetadataInput (empty doc, id, meta)
+        input_full_doc = AddDocumentWithIDAndMetadataInput(
+            collection_name=collection_name, document="", id="id", metadata="{}"
+        )
+        with assert_raises_mcp_error("Document content cannot be empty."):
+            await _add_document_with_id_and_metadata_impl(input_full_doc)
+
+        input_full_id = AddDocumentWithIDAndMetadataInput(
+            collection_name=collection_name, document="doc", id="", metadata="{}"
+        )
+        with assert_raises_mcp_error("Document ID cannot be empty."):
+            await _add_document_with_id_and_metadata_impl(input_full_id)
+
+        input_full_meta = AddDocumentWithIDAndMetadataInput(
+            collection_name=collection_name, document="doc", id="id", metadata=""
+        )
+        with assert_raises_mcp_error("Metadata JSON string cannot be empty."):
+            await _add_document_with_id_and_metadata_impl(input_full_meta)
+
+        # Ensure validation happened before client calls
+        assert mock_validate.call_count > 0
+        mock_client.get_collection.assert_not_called()
+        mock_collection.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_document_with_metadata_success(self, mock_chroma_client_document):
+        """Test successful addition using AddDocumentWithMetadataInput."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_add_with_meta"
+        document_to_add = "doc_m1"  # Singular
+        metadata_str = '{"key": "value1"}'  # Singular JSON string
+        parsed_metadata = {"key": "value1"}  # Expected parsed dict
+
+        # Mock add to capture generated ID
+        generated_id_capture = None
+
+        def capture_add(*args, **kwargs):
+            nonlocal generated_id_capture
+            generated_id_capture = kwargs.get("ids", [None])[0]
+            return None
+
+        mock_collection.add.side_effect = capture_add
+
+        input_model = AddDocumentWithMetadataInput(
+            collection_name=collection_name, document=document_to_add, metadata=metadata_str
+        )
+        result = await _add_document_with_metadata_impl(input_model)
+
+        mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Assert add was called with the PARSED metadata and GENERATED IDs in lists
+        mock_collection.add.assert_called_once_with(documents=[document_to_add], ids=ANY, metadatas=[parsed_metadata])
+        assert generated_id_capture is not None
+        assert_successful_json_result(result, {"added_id": generated_id_capture})
+
+    @pytest.mark.asyncio
+    async def test_add_document_with_id_and_metadata_success(self, mock_chroma_client_document):
+        """Test successful addition using AddDocumentWithIDAndMetadataInput."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_add_full"
+        document_to_add = "doc_f1"  # Singular
+        id_to_add = "id_f1"  # Singular
+        metadata_str = '{"source": "full_test"}'  # Singular JSON string
+        parsed_metadata = {"source": "full_test"}  # Expected parsed dict
+
+        input_model = AddDocumentWithIDAndMetadataInput(
+            collection_name=collection_name, document=document_to_add, id=id_to_add, metadata=metadata_str
+        )
+        result = await _add_document_with_id_and_metadata_impl(input_model)
+
+        mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Assert add was called with the PARSED metadata in list
+        mock_collection.add.assert_called_once_with(
+            documents=[document_to_add], ids=[id_to_add], metadatas=[parsed_metadata]
+        )
+        assert_successful_json_result(result, {"added_id": id_to_add})
+
+    @pytest.mark.asyncio
+    async def test_add_document_invalid_metadata_json(self, mock_chroma_client_document):
+        """Test adding document with invalid metadata JSON string."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_add_invalid_json"
+        document_to_add = "doc_ij1"  # Singular
+        id_to_add = "id_ij1"  # Singular
+        invalid_metadata_str = '{"key": "value1'  # Invalid JSON string
+
+        # Test AddDocumentWithMetadataInput
+        input_meta = AddDocumentWithMetadataInput(
+            collection_name=collection_name, document=document_to_add, metadata=invalid_metadata_str
+        )
+        with assert_raises_mcp_error("Invalid JSON format for metadata string"):
+            await _add_document_with_metadata_impl(input_meta)
+
+        # Test AddDocumentWithIDAndMetadataInput
+        input_full = AddDocumentWithIDAndMetadataInput(
+            collection_name=collection_name, document=document_to_add, id=id_to_add, metadata=invalid_metadata_str
+        )
+        with assert_raises_mcp_error("Invalid JSON format for metadata string"):
+            await _add_document_with_id_and_metadata_impl(input_full)
+
+        mock_validate.assert_called()
+        mock_client.get_collection.assert_not_called()
+        mock_collection.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_document_metadata_not_dict(self, mock_chroma_client_document):
+        """Test adding document where metadata string decodes to non-dict."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_add_meta_not_dict"
+        document_to_add = "doc_nd1"  # Singular
+        id_to_add = "id_nd1"  # Singular
+        not_dict_metadata_str = '["list", "not_dict"]'  # Valid JSON, but not an object/dict
+
+        # Test AddDocumentWithMetadataInput
+        input_meta = AddDocumentWithMetadataInput(
+            collection_name=collection_name, document=document_to_add, metadata=not_dict_metadata_str
+        )
+        with assert_raises_mcp_error("Metadata string did not decode to a dictionary"):
+            await _add_document_with_metadata_impl(input_meta)
+
+        # Test AddDocumentWithIDAndMetadataInput
+        input_full = AddDocumentWithIDAndMetadataInput(
+            collection_name=collection_name, document=document_to_add, id=id_to_add, metadata=not_dict_metadata_str
+        )
+        with assert_raises_mcp_error("Metadata string did not decode to a dictionary"):
+            await _add_document_with_id_and_metadata_impl(input_full)
+
+        mock_validate.assert_called()
+        mock_client.get_collection.assert_not_called()
+        mock_collection.add.assert_not_called()
+
+    # --- Query Documents Tests ---
+
     @pytest.mark.asyncio
     async def test_query_documents_success(self, mock_chroma_client_document):
-        """Test successful document querying."""
+        """Test successful document query."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "query_coll"
-        query_texts = ["query1"]
-        n_results = 2
-        include = ["metadatas", "documents", "distances"]
-        # Mock return value for query
-        mock_result = {
-            "ids": [["id1", "id2"]],
-            "distances": [[0.1, 0.2]],
-            "metadatas": [[{"m": 1}, {"m": 2}]],
-            "embeddings": None, # Not included
-            "documents": [["doc1", "doc2"]],
-            "uris": None, # Not included
-            "data": None, # Not included
-        }
-        # Configure mocks
-        mock_client.get_collection.return_value = mock_collection
-        mock_collection.query.return_value = mock_result
+        collection_name = "test_query_success"
+        query = ["test query"]
+        n_results = 5
+        include_fields = ["metadatas", "documents"]
+        expected_query_result = {"ids": [["id1"]], "documents": [["doc1"]], "metadatas": [[{"key": "val"}]]}
+        mock_collection.query.return_value = expected_query_result
 
         # --- Act ---
         input_model = QueryDocumentsInput(
-            collection_name=collection_name, query_texts=query_texts, n_results=n_results, include=include
+            collection_name=collection_name, query_texts=query, n_results=n_results, include=include_fields
         )
-        # Expect List[TextContent]
-        result_list = await _query_documents_impl(input_model)
+        result = await _query_documents_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
         mock_collection.query.assert_called_once_with(
-            query_texts=query_texts, n_results=n_results, where=None, where_document=None, include=include
+            query_texts=query, n_results=n_results, where=None, where_document=None, include=include_fields
         )
-
-        # Assert successful result format
-        assert isinstance(result_list, list)
-        assert len(result_list) == 1
-        content_item = result_list[0]
-        # Use TextContent, as JSON is embedded in the text field
-        assert isinstance(content_item, types.TextContent)
-        # Verify the structure and content (basic check)
-        parsed_json = json.loads(content_item.text)
-        assert "ids" in parsed_json
-        assert parsed_json["ids"] == mock_result["ids"]
-        assert "distances" in parsed_json
-        assert "documents" in parsed_json
-        assert "metadatas" in parsed_json
+        assert_successful_json_result(result, expected_query_result)
 
     @pytest.mark.asyncio
     async def test_query_documents_collection_not_found(self, mock_chroma_client_document):
-        """Test querying when collection is not found."""
-        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        """Test querying a non-existent collection."""
+        mock_client, _, mock_validate = mock_chroma_client_document
         collection_name = "query_not_found"
         error_message = f"Collection {collection_name} does not exist."
         mock_client.get_collection.side_effect = ValueError(error_message)
 
         # --- Act & Assert ---
         input_model = QueryDocumentsInput(collection_name=collection_name, query_texts=["q"])
-        # Expect McpError
-        # assert excinfo.value.message == f"Tool Error: Collection '{collection_name}' not found."
-        with assert_raises_mcp_error(f"Tool Error: Collection '{collection_name}' not found."):
+        with assert_raises_mcp_error(f"Collection '{collection_name}' not found."):
             await _query_documents_impl(input_model)
 
-        # Assert mocks
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
 
     @pytest.mark.asyncio
     async def test_query_documents_chroma_error(self, mock_chroma_client_document):
-        """Test handling errors during the query process."""
+        """Test handling errors during the actual Chroma query call."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
         collection_name = "query_chroma_fail"
         error_message = "Query failed internally."
-        # Mock get success, query failure
         mock_client.get_collection.return_value = mock_collection
         mock_collection.query.side_effect = Exception(error_message)
 
         # --- Act & Assert ---
         input_model = QueryDocumentsInput(collection_name=collection_name, query_texts=["q"])
-        # Expect McpError
-        # assert excinfo.value.message == f"ChromaDB Error: Failed to query documents. {error_message}"
-        with assert_raises_mcp_error(f"ChromaDB Error: Failed to query documents. {error_message}"):
+        # Updated expected message format
+        with assert_raises_mcp_error(f"An unexpected error occurred during query: {error_message}"):
             await _query_documents_impl(input_model)
 
-        # Assert mocks
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.query.assert_called_once()
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.query.assert_called_once()  # Verify query was attempted
 
-    # --- _get_documents_impl Tests ---
+    # --- Get Documents Tests ---
+
     @pytest.mark.asyncio
     async def test_get_documents_success_by_ids(self, mock_chroma_client_document):
-        """Test successful document retrieval by IDs."""
+        """Test successful get by IDs."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        mock_get_return = {
-            "ids": ["id1", "id3"],
-            "documents": ["doc one", "doc three"],
-            "metadatas": [{"k": 1}, {"k": 3}],
-            "embeddings": None, # Default exclude
-        }
-        mock_collection.get.return_value = mock_get_return
+        collection_name = "test_get_ids_success"
+        ids_to_get = ["id1", "id2"]
+        include_fields = ["metadatas"]
+        expected_get_result = {"ids": ids_to_get, "metadatas": [{"k": "v1"}, {"k": "v2"}]}
+        mock_collection.get.return_value = expected_get_result
 
-        ids_to_get = ["id1", "id3"]
-        collection_name = "test_get_ids"
-        input_model = GetDocumentsInput(collection_name=collection_name, ids=ids_to_get)
-        result = await _get_documents_impl(input_model)
+        # --- Act ---
+        input_model = GetDocumentsByIdsInput(collection_name=collection_name, ids=ids_to_get, include=include_fields)
+        result = await _get_documents_by_ids_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
         mock_collection.get.assert_called_once_with(
-            ids=ids_to_get,
-            where=None,
-            limit=None,
-            offset=None,
-            where_document=None,
-            include=["documents", "metadatas"], # Check actual default include used by _impl
+            ids=ids_to_get, where=None, where_document=None, limit=None, offset=None, include=include_fields
         )
-        # Use helper to parse JSON first - check matches raw return
-        assert_successful_json_result(result, mock_get_return)
+        assert_successful_json_result(result, expected_get_result)
 
     @pytest.mark.asyncio
     async def test_get_documents_success_by_where(self, mock_chroma_client_document):
-        """Test successful get by where filter with limit/offset."""
+        """Test successful get by where filter."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        mock_get_return = {
-            "ids": ["id5"],
-            "documents": ["doc five"], # Only documents included
-            "metadatas": None,
-            "embeddings": None,
-        }
-        mock_collection.get.return_value = mock_get_return
+        collection_name = "test_get_where_success"
+        where_filter = {"status": "active"}
+        limit, offset = 10, 0
+        expected_get_result = {"ids": ["id_w1"], "documents": ["doc_w1"], "metadatas": [{"status": "active"}]}
+        mock_collection.get.return_value = expected_get_result
 
-        where_filter = {"tag": "test"}
-        limit = 1
-        offset = 2
-        collection_name = "test_get_where"
-        include = ["documents"]
-        input_model = GetDocumentsInput(
-            collection_name=collection_name, where=where_filter, limit=limit, offset=offset, include=include
+        # --- Act ---
+        input_model = GetDocumentsWithWhereFilterInput(
+            collection_name=collection_name, where=where_filter, limit=limit, offset=offset
         )
-        result = await _get_documents_impl(input_model)
+        result = await _get_documents_with_where_filter_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
         mock_collection.get.assert_called_once_with(
-            ids=None,
-            where=where_filter,
-            limit=limit,
-            offset=offset,
-            where_document=None,
-            include=include, # Check custom include
+            ids=None, where=where_filter, where_document=None, limit=limit, offset=offset, include=[]  # default include
         )
-        # Use helper to parse JSON - check matches raw return
-        assert_successful_json_result(result, mock_get_return)
+        assert_successful_json_result(result, expected_get_result)
+
+    # Test for GetDocumentsWithDocumentFilterInput - similar structure
+    @pytest.mark.asyncio
+    async def test_get_documents_success_by_where_doc(self, mock_chroma_client_document):
+        """Test successful get by where_document filter."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_get_wheredoc_success"
+        where_doc_filter = {"$contains": "obsolete"}
+        expected_get_result = {"ids": ["id_wd1"], "documents": ["very important doc"]}
+        mock_collection.get.return_value = expected_get_result
+
+        input_model = GetDocumentsWithDocumentFilterInput(
+            collection_name=collection_name, where_document=where_doc_filter
+        )
+        result = await _get_documents_with_document_filter_impl(input_model)
+
+        mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.get.assert_called_once_with(
+            ids=None, where=None, where_document=where_doc_filter, limit=None, offset=None, include=[]
+        )
+        assert_successful_json_result(result, expected_get_result)
+
+    # Test for GetAllDocumentsInput - similar structure
+    @pytest.mark.asyncio
+    async def test_get_all_documents_success(self, mock_chroma_client_document):
+        """Test successful get all documents."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_get_all_success"
+        limit = 5
+        expected_get_result = {
+            "ids": [f"id_a{i}" for i in range(limit)],
+            "documents": [f"doc_a{i}" for i in range(limit)],
+        }
+        mock_collection.get.return_value = expected_get_result
+
+        input_model = GetAllDocumentsInput(collection_name=collection_name, limit=limit)
+        result = await _get_all_documents_impl(input_model)
+
+        mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.get.assert_called_once_with(
+            ids=None, where=None, where_document=None, limit=limit, offset=None, include=[]
+        )
+        assert_successful_json_result(result, expected_get_result)
+
+    @pytest.mark.skip(reason="Include value validation now primarily handled by Pydantic model.")
+    @pytest.mark.asyncio
+    async def test_get_documents_validation_invalid_include(self, mock_chroma_client_document):
+        """Test validation failure for invalid include values."""
+        mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "test_get_valid_include"
+        # This test needs adjustment based on where include validation happens
+        # If Pydantic handles it, test the dispatcher/server level
+        # If _impl handles it, mock appropriately
+
+        input_model = GetDocumentsByIdsInput(
+            collection_name=collection_name, ids=["id1"], include=["invalid_field"]  # Invalid field
+        )
+
+        # Example: Assuming _impl or a helper raises McpError for invalid include
+        with assert_raises_mcp_error("Invalid include field"):  # Adjust expected message
+            await _get_documents_by_ids_impl(input_model)
 
     @pytest.mark.asyncio
     async def test_get_documents_validation_no_criteria(self, mock_chroma_client_document):
-        """Test validation failure when no criteria (ids/where/where_doc) provided."""
+        """Test validation failure when no specific criteria provided to a specific getter."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_get_valid"
-        input_model = GetDocumentsInput(collection_name=collection_name)
-        # Expect validation error raised by _impl
-        with assert_raises_mcp_error("Validation Error: At least one of ids, where, or where_document must be provided for get."):
-            await _get_documents_impl(input_model)
-        # Check validator was called before error
-        mock_validate.assert_called_once_with(collection_name)
+        collection_name = "test_get_valid_criteria"
 
-    @pytest.mark.asyncio
-    async def test_get_documents_validation_invalid_include(self, mock_chroma_client_document):
-        """Test validation failure with invalid include values."""
-        # NOTE: Pydantic now handles Literal validation for include. This test might become obsolete
-        # if we solely rely on Pydantic. Keeping it for now if _impl does extra checks.
-        mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_get_valid_inc"
-        input_model = GetDocumentsInput(
-            collection_name=collection_name, ids=["id1"], include=["documents", "invalid_field"]
-        )
-        # This will likely fail Pydantic validation *before* _impl is called.
-        # If _impl *does* validate, we need to adjust this:
-        # with assert_raises_mcp_error("Validation Error: Invalid item(s) in include list"):
-        #     await _get_documents_impl(input_model)
-        pytest.skip("Include value validation now primarily handled by Pydantic model.")
-        # result = await _get_documents_impl(input_model)
-        # assert result.isError is True
-        # assert "Validation Error: Invalid item(s) in include list" in result.content[0].text
+        # Test GetDocumentsByIdsInput with empty list (should fail in _impl)
+        input_ids_empty = GetDocumentsByIdsInput(collection_name=collection_name, ids=[])
+        with assert_raises_mcp_error("IDs list cannot be empty for get_documents_by_ids."):
+            await _get_documents_by_ids_impl(input_ids_empty)
+
+        # Pydantic ensures where/where_document are provided for other variants, so no test needed here
+        # for empty filters on those specific tool variants.
+
+        # Ensure validation happened before client calls
+        mock_validate.assert_called()
+        mock_client.get_collection.assert_not_called()
+        mock_collection.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_documents_collection_not_found(self, mock_chroma_client_document):
@@ -543,317 +677,301 @@ class TestDocumentTools:
         error_message = f"Collection {collection_name} does not exist."
         mock_client.get_collection.side_effect = ValueError(error_message)
 
-        # --- Act & Assert ---
-        input_model = GetDocumentsInput(collection_name=collection_name, ids=["id1"])
-        with assert_raises_mcp_error(f"Tool Error: Collection '{collection_name}' not found."):
-            await _get_documents_impl(input_model)
+        # Test one variant, e.g., GetDocumentsByIdsInput
+        input_model = GetDocumentsByIdsInput(collection_name=collection_name, ids=["id1"])
+        with assert_raises_mcp_error(f"Collection '{collection_name}' not found."):
+            await _get_documents_by_ids_impl(input_model)
 
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
 
     @pytest.mark.asyncio
     async def test_get_documents_chroma_error(self, mock_chroma_client_document):
-        """Test handling errors during the actual get call."""
+        """Test handling errors during the actual Chroma get call."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
         collection_name = "get_chroma_fail"
         error_message = "Get failed internally."
-        # Mock get success, query failure
         mock_client.get_collection.return_value = mock_collection
         mock_collection.get.side_effect = Exception(error_message)
 
-        # --- Act & Assert ---
-        input_model = GetDocumentsInput(collection_name=collection_name, ids=["id1"])
-        with assert_raises_mcp_error(f"ChromaDB Error: Failed to get documents. {error_message}"):
-            await _get_documents_impl(input_model)
+        # Test one variant, e.g., GetDocumentsByIdsInput
+        input_model = GetDocumentsByIdsInput(collection_name=collection_name, ids=["id1"])
+        # Updated expected message format
+        with assert_raises_mcp_error(f"An unexpected error occurred during get: {error_message}"):
+            await _get_documents_by_ids_impl(input_model)
 
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.get.assert_called_once()
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.get.assert_called_once()  # Verify get was attempted
 
-    # --- _update_documents_impl Tests ---
+    # --- Update Documents Tests ---
+
     @pytest.mark.asyncio
-    async def test_update_documents_success(self, mock_chroma_client_document):
-        """Test successful document update (content and metadata)."""
+    async def test_update_document_content_success(self, mock_chroma_client_document):
+        """Test successful document update (content only)."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_update"
-        ids_to_update = ["id_u1", "id_u2"]
-        new_docs = ["new doc 1", "new doc 2"]
-        new_metas = [{'k': 'v_new1'}, {'k': 'v_new2'}]
+        collection_name = "test_update_success"
+        id_to_update = "id1"  # Singular
+        new_doc = "new_doc1"  # Singular
 
         # --- Act ---
-        input_model = UpdateDocumentsInput(
-            collection_name=collection_name, ids=ids_to_update, documents=new_docs, metadatas=new_metas
-        )
-        result = await _update_documents_impl(input_model)
+        input_model = UpdateDocumentContentInput(collection_name=collection_name, id=id_to_update, document=new_doc)
+        result = await _update_document_content_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.update.assert_called_once_with(ids=ids_to_update, documents=new_docs, metadatas=new_metas)
-        # Check successful result JSON using helper
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("status") == "success"
-        assert result_data.get("processed_count") == 2
-        assert result_data.get("collection_name") == collection_name
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Assert update called with list of size 1
+        mock_collection.update.assert_called_once_with(ids=[id_to_update], documents=[new_doc], metadatas=None)
+        # Assert result contains the updated ID
+        assert_successful_json_result(result, {"updated_id": id_to_update})
 
     @pytest.mark.asyncio
-    async def test_update_documents_only_metadata(self, mock_chroma_client_document):
-        """Test updating only metadata."""
+    async def test_update_document_metadata_success(self, mock_chroma_client_document):
+        """Test successful document update (metadata only)."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_update_meta"
-        ids_to_update = ["id_m1"]
-        new_metas = [{'status': 'updated'}]
+        collection_name = "test_update_meta_success"
+        id_to_update = "id_m1"  # Singular
+        new_metadata = {"status": "updated"}  # Singular dict
 
         # --- Act ---
-        input_model = UpdateDocumentsInput(
-            collection_name=collection_name, ids=ids_to_update, metadatas=new_metas
+        input_model = UpdateDocumentMetadataInput(
+            collection_name=collection_name, id=id_to_update, metadata=new_metadata
         )
-        result = await _update_documents_impl(input_model)
+        result = await _update_document_metadata_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        # Check update called with documents=None
-        mock_collection.update.assert_called_once_with(ids=ids_to_update, documents=None, metadatas=new_metas)
-        # Check successful result JSON using helper
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("status") == "success"
-        assert result_data.get("processed_count") == 1
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Assert update called with list of size 1
+        mock_collection.update.assert_called_once_with(ids=[id_to_update], documents=None, metadatas=[new_metadata])
+        assert_successful_json_result(result, {"updated_id": id_to_update})
 
     @pytest.mark.asyncio
-    async def test_update_documents_validation_mismatch(self, mock_chroma_client_document):
-        """Test validation failure with mismatched list lengths."""
+    async def test_update_document_validation_missing_args(self, mock_chroma_client_document):
+        """Test validation failure for missing id or metadata."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_update_valid_match"
-        input_model = UpdateDocumentsInput(
-            collection_name=collection_name, ids=["id1"], documents=["d1", "d2"] # Mismatch
-        )
-        # Expect McpError
-        with assert_raises_mcp_error("Validation Error: Number of documents must match number of IDs"):
-            await _update_documents_impl(input_model)
-        mock_validate.assert_called_once_with(collection_name) # Validator called before error
+        collection_name = "test_update_valid_missing"
+
+        # Test content update missing ID
+        input_content = UpdateDocumentContentInput(collection_name=collection_name, id="", document="doc1")
+        with assert_raises_mcp_error("ID cannot be empty for update."):
+            await _update_document_content_impl(input_content)
+
+        # Test metadata update missing ID
+        input_meta_id = UpdateDocumentMetadataInput(collection_name=collection_name, id="", metadata={"k": "v"})
+        with assert_raises_mcp_error("ID cannot be empty for update."):
+            await _update_document_metadata_impl(input_meta_id)
+
+        # Test metadata update missing metadata (Note: Pydantic handles None, check empty dict? Source code checks for None)
+        # Pydantic should prevent None based on model def, test source logic if needed
+        # Let's assume Pydantic allows empty dict, test that if required by source
+        # input_meta_meta = UpdateDocumentMetadataInput(
+        #     collection_name=collection_name, id="id1", metadata={}
+        # )
+        # with assert_raises_mcp_error("Metadata cannot be empty/null for update."): # Adjust if source allows empty dict
+        #     await _update_document_metadata_impl(input_meta_meta)
+
+        mock_validate.assert_called()
+        mock_client.get_collection.assert_not_called()
+        mock_collection.update.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_update_documents_collection_not_found(self, mock_chroma_client_document):
-        """Test updating documents when the collection is not found."""
+    async def test_update_document_collection_not_found(self, mock_chroma_client_document):
+        """Test updating document when the collection is not found."""
         mock_client, _, mock_validate = mock_chroma_client_document
         collection_name = "update_not_found"
         error_message = f"Collection {collection_name} does not exist."
         mock_client.get_collection.side_effect = ValueError(error_message)
 
-        # --- Act & Assert ---
-        input_model = UpdateDocumentsInput(collection_name=collection_name, ids=["id1"], documents=["d"])
-        with assert_raises_mcp_error(f"Tool Error: Collection '{collection_name}' not found."):
-            await _update_documents_impl(input_model)
+        input_model = UpdateDocumentContentInput(collection_name=collection_name, id="id1", document="d")
+        with assert_raises_mcp_error(f"Collection '{collection_name}' not found."):
+            await _update_document_content_impl(input_model)
 
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
 
     @pytest.mark.asyncio
-    async def test_update_documents_chroma_error(self, mock_chroma_client_document):
-        """Test handling errors during the actual update call."""
+    async def test_update_document_chroma_error(self, mock_chroma_client_document):
+        """Test handling errors during the actual Chroma update call."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
         collection_name = "update_chroma_fail"
         error_message = "Update failed internally."
-        # Mock get success, update failure
         mock_client.get_collection.return_value = mock_collection
         mock_collection.update.side_effect = Exception(error_message)
 
-        # --- Act & Assert ---
-        input_model = UpdateDocumentsInput(collection_name=collection_name, ids=["id1"], documents=["d"])
-        with assert_raises_mcp_error(f"ChromaDB Error: Failed to update documents. {error_message}"):
-            await _update_documents_impl(input_model)
+        input_model = UpdateDocumentContentInput(collection_name=collection_name, id="id1", document="d")
+        with assert_raises_mcp_error(f"ChromaDB Error: Failed to update document content. {error_message}"):
+            await _update_document_content_impl(input_model)
 
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.update.assert_called_once()
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.update.assert_called_once()  # Verify update was attempted
 
-    # --- _delete_documents_impl Tests ---
+    # --- Delete Documents Tests ---
+
     @pytest.mark.asyncio
-    async def test_delete_documents_success_by_ids(self, mock_chroma_client_document):
-        """Test successful deletion by IDs."""
+    async def test_delete_document_by_id_success(self, mock_chroma_client_document):
+        """Test successful deletion by ID."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_delete_ids"
-        ids_to_delete = ["id_del1", "id_del2"]
-        # Mock the return value of delete (list of IDs that were deleted)
-        mock_collection.delete.return_value = ids_to_delete
+        collection_name = "test_delete_id"
+        id_to_delete = "id_del1"  # Singular
+        # Mock delete returns the list of IDs provided if successful
+        mock_collection.delete.return_value = [id_to_delete]
 
         # --- Act ---
-        input_model = DeleteDocumentsInput(collection_name=collection_name, ids=ids_to_delete)
-        result = await _delete_documents_impl(input_model)
+        input_model = DeleteDocumentByIdInput(collection_name=collection_name, id=id_to_delete)
+        result = await _delete_document_by_id_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.delete.assert_called_once_with(ids=ids_to_delete, where=None, where_document=None)
-        # Check successful result JSON using helper
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("status") == "success"
-        assert result_data.get("deleted_ids") == ids_to_delete
-        assert result_data.get("collection_name") == collection_name
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Assert delete called with only list of IDs (where/where_document default to None)
+        mock_collection.delete.assert_called_once_with(ids=[id_to_delete])
+
+        # --- Assert Result ---
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], types.TextContent)
+        assert result[0].type == "text"
+        # Assert the correct plain text message
+        assert result[0].text == f"Deletion requested for document ID: {id_to_delete}"
 
     @pytest.mark.asyncio
-    async def test_delete_documents_success_by_where(self, mock_chroma_client_document):
-        """Test successful deletion by where filter."""
+    async def test_delete_document_by_id_not_found_silent(self, mock_chroma_client_document):
+        """Test deletion by ID when ID doesn't exist (Chroma returns empty list)."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
-        collection_name = "test_delete_where"
-        where_filter = {"status": "to_delete"}
-        # Mock delete return value
-        deleted_ids_returned = ["id_matched1", "id_matched2"]
-        mock_collection.delete.return_value = deleted_ids_returned
+        collection_name = "test_delete_id_silent"
+        id_to_delete = "non_existent_id"  # Singular
+        # Mock delete returns empty list when ID not found
+        mock_collection.delete.return_value = []
 
         # --- Act ---
-        input_model = DeleteDocumentsInput(collection_name=collection_name, where=where_filter)
-        result = await _delete_documents_impl(input_model)
+        input_model = DeleteDocumentByIdInput(collection_name=collection_name, id=id_to_delete)
+        result = await _delete_document_by_id_impl(input_model)
 
         # --- Assert ---
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.delete.assert_called_once_with(ids=None, where=where_filter, where_document=None)
-        # Check successful result JSON using helper
-        result_data = assert_successful_json_result(result)
-        assert result_data.get("status") == "success"
-        assert result_data.get("deleted_ids") == deleted_ids_returned
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        # Assert delete called with only list of IDs (where/where_document default to None)
+        mock_collection.delete.assert_called_once_with(ids=[id_to_delete])
+
+        # --- Assert Result ---
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], types.TextContent)
+        assert result[0].type == "text"
+        # Assert the correct plain text message (implementation returns this even if ID not found by Chroma)
+        assert result[0].text == f"Deletion requested for document ID: {id_to_delete}"
 
     @pytest.mark.asyncio
-    async def test_delete_documents_validation_no_criteria(self, mock_chroma_client_document):
-        """Test validation failure when no criteria (ids/where/where_doc) provided."""
+    async def test_delete_document_validation_no_id(self, mock_chroma_client_document):
+        """Test validation failure when ID is empty."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
         collection_name = "test_delete_valid"
-        input_model = DeleteDocumentsInput(collection_name=collection_name)
-        # Expect McpError
-        with assert_raises_mcp_error("Validation Error: At least one of ids, where, or where_document must be provided for deletion."):
-            await _delete_documents_impl(input_model)
+
+        input_model = DeleteDocumentByIdInput(collection_name=collection_name, id="")
+        with assert_raises_mcp_error("ID cannot be empty for delete_document_by_id."):
+            await _delete_document_by_id_impl(input_model)
+
         mock_validate.assert_called_once_with(collection_name)
+        mock_client.get_collection.assert_not_called()
+        mock_collection.delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_delete_documents_collection_not_found(self, mock_chroma_client_document):
-        """Test deleting documents when the collection is not found."""
+    async def test_delete_document_collection_not_found(self, mock_chroma_client_document):
+        """Test deleting document when the collection is not found."""
         mock_client, _, mock_validate = mock_chroma_client_document
         collection_name = "delete_not_found"
         error_message = f"Collection {collection_name} does not exist."
         mock_client.get_collection.side_effect = ValueError(error_message)
 
-        # --- Act & Assert ---
-        input_model = DeleteDocumentsInput(collection_name=collection_name, ids=["id1"])
-        with assert_raises_mcp_error(f"Tool Error: Collection '{collection_name}' not found."):
-            await _delete_documents_impl(input_model)
+        input_model = DeleteDocumentByIdInput(collection_name=collection_name, id="id1")
+        with assert_raises_mcp_error(f"Collection '{collection_name}' not found."):
+            await _delete_document_by_id_impl(input_model)
 
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
 
     @pytest.mark.asyncio
-    async def test_delete_documents_chroma_error(self, mock_chroma_client_document):
+    async def test_delete_document_chroma_error(self, mock_chroma_client_document):
         """Test handling errors during the actual delete call."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
         collection_name = "delete_chroma_fail"
         error_message = "Delete failed internally."
-        # Mock get success, delete failure
         mock_client.get_collection.return_value = mock_collection
         mock_collection.delete.side_effect = Exception(error_message)
 
-        # --- Act & Assert ---
-        input_model = DeleteDocumentsInput(collection_name=collection_name, ids=["id1"])
-        with assert_raises_mcp_error(f"ChromaDB Error: Failed to delete documents. {error_message}"):
-            await _delete_documents_impl(input_model)
+        input_model = DeleteDocumentByIdInput(collection_name=collection_name, id="id1")
+        with assert_raises_mcp_error(f"ChromaDB Error: Failed to delete document. {error_message}"):
+            await _delete_document_by_id_impl(input_model)
 
         mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
-        mock_collection.delete.assert_called_once()
+        mock_client.get_collection.assert_called_once_with(name=collection_name)
+        mock_collection.delete.assert_called_once()  # Verify delete was attempted
 
-    # --- Generic Error Handling Test ---
+    # --- Generic Error Handling Test (Updated for singular ops) ---
+
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "tool_impl_func, chroma_method_name, args, kwargs, expected_error_msg_part",
-        [
-            # Add missing required args to kwargs for each tool
-            (
-                _add_documents_impl,
-                "add",
-                [],
-                {"collection_name": "c", "documents": ["d"]}, # increment_index defaults to True
-                "add documents",
-            ),
-            (
-                _query_documents_impl,
-                "query",
-                [],
-                {"collection_name": "c", "query_texts": ["q"]}, # n_results defaults to 10
-                "query documents",
-            ),
-            # (
-            #     _get_documents_impl,
-            #     "get",
-            #     [],
-            #     {"collection_name": "c", "ids": ["id1"]}, # limit, offset default None
-            #     "getting documents",
-            # ),
-            # (
-            #     _update_documents_impl,
-            #     "update",
-            #     [],
-            #     {"collection_name": "c", "ids": ["id1"], "documents": ["d"]},
-            #     "updating documents",
-            # ),
-            # (_delete_documents_impl, "delete", [], {"collection_name": "c", "ids": ["id1"]}, "deleting documents"),
-        ],
-    )
-    async def test_generic_chroma_error_handling(
-        self, mock_chroma_client_document, tool_impl_func, chroma_method_name, args, kwargs, expected_error_msg_part
-    ):
-        """Tests that unexpected ChromaDB errors during tool execution raise McpError."""
+    async def test_generic_chroma_error_handling(self, mock_chroma_client_document):
+        """Test that generic ChromaDB errors are caught and wrapped in McpError."""
         mock_client, mock_collection, mock_validate = mock_chroma_client_document
+        collection_name = "generic_error_test"
+        generic_error_message = "A generic ChromaDB internal error occurred."
 
-        # Setup the mock collection method to raise an error
-        error_message = "Simulated ChromaDB Failure"
-        getattr(mock_collection, chroma_method_name).side_effect = Exception(error_message)
+        # --- Test Add (Singular) --- #
+        mock_client.get_collection.reset_mock(side_effect=None)
+        mock_client.get_collection.return_value = mock_collection
+        # Correctly mock the failure on the collection's add method
+        mock_collection.add.side_effect = Exception(generic_error_message)
+        input_add = AddDocumentInput(collection_name=collection_name, document="d")  # Singular
+        with assert_raises_mcp_error(f"An unexpected error occurred: {generic_error_message}"):
+            await _add_document_impl(input_add)
+        mock_validate.assert_called_with(collection_name)
+        mock_client.get_collection.assert_called_with(name=collection_name)
+        mock_collection.add.assert_called_once()
+        mock_client.reset_mock()
+        mock_collection.reset_mock()
+        mock_validate.reset_mock()
 
-        # Determine the correct Pydantic model based on the function
-        if tool_impl_func == _add_documents_impl:
-            InputModel = AddDocumentsInput
-        elif tool_impl_func == _query_documents_impl:
-            InputModel = QueryDocumentsInput
-        # elif tool_impl_func == _get_documents_impl:
-        #     InputModel = GetDocumentsInput
-        # elif tool_impl_func == _update_documents_impl:
-        #     InputModel = UpdateDocumentsInput
-        # elif tool_impl_func == _delete_documents_impl:
-        #     InputModel = DeleteDocumentsInput
-        else:
-            pytest.fail(f"Unknown tool_impl_func: {tool_impl_func}")
+        # --- Test Query (Unchanged) --- #
+        mock_client.get_collection.return_value = mock_collection
+        mock_collection.query.side_effect = Exception(generic_error_message)
+        input_query = QueryDocumentsInput(collection_name=collection_name, query_texts=["q"])
+        with assert_raises_mcp_error(f"An unexpected error occurred during query: {generic_error_message}"):
+            await _query_documents_impl(input_query)
+        mock_validate.assert_called_with(collection_name)
+        mock_client.get_collection.assert_called_with(name=collection_name)
+        mock_collection.query.assert_called_once()
+        mock_client.reset_mock()
+        mock_collection.reset_mock()
+        mock_validate.reset_mock()
 
-        # Instantiate the model with the provided kwargs
-        try:
-            input_model = InputModel(**kwargs)
-        except ValidationError as e:
-            pytest.fail(f"Failed to instantiate Pydantic model {InputModel.__name__} with kwargs {kwargs}: {e}")
+        # --- Test Update (Content - Singular) --- #
+        mock_client.get_collection.return_value = mock_collection
+        mock_collection.update.side_effect = Exception(generic_error_message)
+        input_update_content = UpdateDocumentContentInput(
+            collection_name=collection_name, id="id1", document="d"
+        )  # Singular
+        with assert_raises_mcp_error(
+            f"ChromaDB Error: Failed to update document content. {generic_error_message}"
+        ):  # Updated msg
+            await _update_document_content_impl(input_update_content)
+        mock_validate.assert_called_with(collection_name)
+        mock_client.get_collection.assert_called_with(name=collection_name)
+        mock_collection.update.assert_called_once()
+        mock_client.reset_mock()
+        mock_collection.reset_mock()
+        mock_validate.reset_mock()
 
-        # Call the tool implementation function and expect McpError
-        # result = await tool_impl_func(input_model)
-        # assert result.isError is True
-        # assert f"Error: Failed to {expected_error_msg_part}" in result.content[0].text
-        # assert error_message in result.content[0].text
-        with assert_raises_mcp_error(error_message): # Check the original exception message is included
-            await tool_impl_func(input_model)
-
-    # Test query collection not found specifically (still returns CallToolResult)
-    @pytest.mark.asyncio
-    async def test_query_collection_not_found(self, mock_chroma_client_document):
-        """Test querying a non-existent collection (using specific test)."""
-        mock_client, _, mock_validate = mock_chroma_client_document
-        collection_name = "non_existent_coll"
-        # Configure the client's get_collection mock to raise the specific ValueError
-        error_message = f"Collection {collection_name} does not exist."
-        mock_client.get_collection.side_effect = ValueError(error_message)
-
-        # ACT & Assert
-        input_model = QueryDocumentsInput(collection_name=collection_name, query_texts=["test"])
-        # result = await _query_documents_impl(input_model)
-        # assert result.isError is True
-        # assert f"Tool Error: Collection '{collection_name}' not found." in result.content[0].text
-        with assert_raises_mcp_error(f"Tool Error: Collection '{collection_name}' not found."):
-            await _query_documents_impl(input_model)
-
-        # Assert mocks were called correctly
-        mock_validate.assert_called_once_with(collection_name)
-        mock_client.get_collection.assert_called_once_with(name=collection_name, embedding_function=ANY)
+        # --- Test Delete (Singular ID) --- #
+        mock_client.get_collection.return_value = mock_collection
+        mock_collection.delete.side_effect = Exception(generic_error_message)
+        input_delete = DeleteDocumentByIdInput(collection_name=collection_name, id="id1")  # Singular
+        with assert_raises_mcp_error(
+            f"ChromaDB Error: Failed to delete document. {generic_error_message}"
+        ):  # Updated msg
+            await _delete_document_by_id_impl(input_delete)
+        mock_validate.assert_called_with(collection_name)
+        mock_client.get_collection.assert_called_with(name=collection_name)
+        mock_collection.delete.assert_called_once()

--- a/tests/utils/test_init.py
+++ b/tests/utils/test_init.py
@@ -1,0 +1,166 @@
+"""Tests for src/chroma_mcp/utils/__init__.py"""
+
+import logging
+import pytest
+import numpy as np
+import json
+from unittest.mock import patch, MagicMock
+import sys
+
+# Import functions and classes to test from the __init__ module
+from src.chroma_mcp.utils import (
+    set_main_logger,
+    set_server_config,
+    get_logger,
+    get_server_config,
+    NumpyEncoder,
+    BASE_LOGGER_NAME,
+)
+from src.chroma_mcp.types import ChromaClientConfig
+from mcp.shared.exceptions import McpError
+
+# Import the module containing the globals
+import src.chroma_mcp.utils as utils_target_module
+
+# Keep track of original state to restore after tests
+original_logger = None
+original_config = None
+
+
+def setup_module(module):
+    """Save original global state before tests run."""
+    global original_logger, original_config
+    # Use internal access for testing setup/teardown on the TARGET module
+    original_logger = utils_target_module._main_logger_instance
+    original_config = utils_target_module._global_client_config
+    # Reset before running tests in this module
+    reset_globals()
+
+
+def teardown_module(module):
+    """Restore original global state after tests run."""
+    # Use internal access for testing setup/teardown on the TARGET module
+    utils_target_module._main_logger_instance = original_logger
+    utils_target_module._global_client_config = original_config
+
+
+def reset_globals():
+    """Helper to reset globals before each test needing isolation."""
+    # Use internal access for testing setup/teardown
+    utils_target_module._main_logger_instance = None
+    utils_target_module._global_client_config = None
+
+
+# --- Tests for Logger ---
+
+
+def test_set_and_get_main_logger():
+    """Test setting and getting the main logger instance."""
+    reset_globals()
+    mock_logger = MagicMock(spec=logging.Logger)
+    set_main_logger(mock_logger)
+    retrieved_logger = get_logger()
+    assert retrieved_logger is mock_logger
+
+
+def test_get_child_logger():
+    """Test getting a child logger after main logger is set."""
+    reset_globals()
+    mock_logger = logging.getLogger(f"{BASE_LOGGER_NAME}_test_parent")
+    set_main_logger(mock_logger)
+    child_name = "child_test"
+    child_logger = get_logger(child_name)
+    assert child_logger.name == f"{BASE_LOGGER_NAME}.{child_name}"
+    # Check it's a child of the base logger, not necessarily the exact instance set
+    assert child_logger.parent.name == BASE_LOGGER_NAME
+
+
+# @patch("logging.StreamHandler") # Remove this patch
+def test_get_logger_before_config():  # Already removed mock_stream_handler arg
+    """Test getting logger before set_main_logger is called."""
+    reset_globals()
+    # Ensure the target logger really has no handlers before the test
+    fallback_logger_name = f"{BASE_LOGGER_NAME}.unconfigured"
+    logging.getLogger(fallback_logger_name).handlers.clear()
+    # Also reset propagation if necessary, although unlikely needed here
+    # logging.getLogger(fallback_logger_name).propagate = True
+
+    logger = get_logger()  # This should now add the handler
+
+    assert logger.name == fallback_logger_name
+
+    # Check that the logger has exactly one StreamHandler targeting stderr
+    assert len(logger.handlers) == 1, f"Expected 1 handler, found {len(logger.handlers)}"
+    handler = logger.handlers[0]
+    assert isinstance(handler, logging.StreamHandler), f"Expected StreamHandler, got {type(handler)}"
+    assert handler.stream == sys.stderr, "Handler stream is not sys.stderr"
+
+    # Clean up handler added by this test to avoid affecting others
+    logger.removeHandler(handler)
+
+
+# --- Tests for Server Config ---
+
+
+def test_set_and_get_server_config():
+    """Test setting and getting the server config."""
+    reset_globals()
+    mock_config = ChromaClientConfig(client_type="ephemeral")
+    set_server_config(mock_config)
+    retrieved_config = get_server_config()
+    assert retrieved_config is mock_config
+
+
+def test_get_server_config_before_set():
+    """Test getting server config before it's set raises McpError."""
+    reset_globals()
+    with pytest.raises(McpError) as excinfo:
+        get_server_config()
+    assert "Server configuration not initialized" in str(excinfo.value)
+
+
+# --- Tests for NumpyEncoder ---
+
+
+def test_numpy_encoder_ints():
+    """Test NumpyEncoder with various numpy integer types."""
+    data = {
+        "np_int8": np.int8(1),
+        "np_int16": np.int16(2),
+        "np_int32": np.int32(3),
+        "np_int64": np.int64(4),
+        "np_uint8": np.uint8(5),
+        "py_int": 6,
+    }
+    expected_json = '{"np_int8": 1, "np_int16": 2, "np_int32": 3, "np_int64": 4, "np_uint8": 5, "py_int": 6}'
+    assert json.dumps(data, cls=NumpyEncoder) == expected_json
+
+
+def test_numpy_encoder_floats():
+    """Test NumpyEncoder with various numpy float types."""
+    data = {
+        "np_float16": np.float16(1.5),
+        "np_float32": np.float32(2.5),
+        "np_float64": np.float64(3.5),
+        "py_float": 4.5,
+    }
+    expected_json = '{"np_float16": 1.5, "np_float32": 2.5, "np_float64": 3.5, "py_float": 4.5}'
+    assert json.dumps(data, cls=NumpyEncoder) == expected_json
+
+
+def test_numpy_encoder_ndarray():
+    """Test NumpyEncoder with a numpy ndarray."""
+    data = {"array": np.array([[1, 2], [3, 4]])}
+    expected_json = '{"array": [[1, 2], [3, 4]]}'
+    assert json.dumps(data, cls=NumpyEncoder) == expected_json
+
+
+def test_numpy_encoder_unhandled_type():
+    """Test NumpyEncoder falls back to superclass for unhandled types."""
+
+    class Unhandled:
+        pass
+
+    data = {"unhandled": Unhandled()}
+    with pytest.raises(TypeError):
+        json.dumps(data, cls=NumpyEncoder)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Refactor tool calls to avoid Dict[str|any] types and increase test coverage

Fixes # (issue)

- MCP clients such as GitHub CoPilot are not handling the Dict[str|any] or in general Union types as it should be, therefore tools fail on validation based on list_tools() call

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Unit Tests successful
- [x] Test Coverage increased to > 70%
- [x] Validated most tools were running in cursor as MCP (not all tools tested yet, tbd.)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
